### PR TITLE
Removes unused hangupsjs client instance. Fixes #16

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -9,8 +9,6 @@ clipboard = require 'clipboard'
 
 tmp.setGracefulCleanup()
 
-client = new Client()
-
 app = require 'app'
 BrowserWindow = require 'browser-window'
 


### PR DESCRIPTION
This fixes #16 . The main thread currently creates a hangupsjs client instance `client = new Client()` without the correct options which is overridden with the right instance a couple lines below. The first instance without the `cookiespath` causes that hangupsjs tries to write a potentially not writable directory (e.g. is installed globally).