### PR TITLE
Proxy support

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -59,11 +59,11 @@ app.on 'ready', ->
 
         # Format of proxyURL is either "DIRECT" or "PROXY 127.0.0.1:8888"
 
-        app.resolveProxy 'https://google.com', (proxyURL) ->
+        app.resolveProxy 'https://plus.google.com', (proxyURL) ->
             return if proxyURL is 'DIRECT'
             process.env.HTTPS_PROXY ?= proxyURL.split(' ')[1]
 
-        app.resolveProxy 'http://google.com', (proxyURL) ->
+        app.resolveProxy 'http://plus.google.com', (proxyURL) ->
             return if proxyURL is 'DIRECT'
             process.env.HTTP_PROXY ?= proxyURL.split(' ')[1]
 

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -10,6 +10,13 @@ clipboard = require 'clipboard'
 tmp.setGracefulCleanup()
 
 app = require 'app'
+
+app.resolveProxy 'https://google.com', (proxyURL) ->
+  process.env.HTTPS_PROXY ?= proxyURL
+
+app.resolveProxy 'http://google.com', (proxyURL) ->
+  process.env.HTTP_PROXY ?= proxyURL
+
 BrowserWindow = require 'browser-window'
 
 paths =

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -11,12 +11,6 @@ tmp.setGracefulCleanup()
 
 app = require 'app'
 
-app.resolveProxy 'https://google.com', (proxyURL) ->
-  process.env.HTTPS_PROXY ?= proxyURL
-
-app.resolveProxy 'http://google.com', (proxyURL) ->
-  process.env.HTTP_PROXY ?= proxyURL
-
 BrowserWindow = require 'browser-window'
 
 paths =
@@ -60,6 +54,14 @@ loadAppWindow = ->
 wait = (t) -> Q.Promise (rs) -> setTimeout rs, t
 
 app.on 'ready', ->
+
+    setImmediate ->
+
+        app.resolveProxy 'http://google.com', (proxyURL) ->
+            process.env.HTTP_PROXY ?= proxyURL
+
+        app.resolveProxy 'https://google.com', (proxyURL) ->
+            process.env.HTTPS_PROXY ?= proxyURL
 
     # Create the browser window.
     mainWindow = new BrowserWindow {

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -61,11 +61,11 @@ app.on 'ready', ->
 
         app.resolveProxy 'https://plus.google.com', (proxyURL) ->
             return if proxyURL is 'DIRECT'
-            process.env.HTTPS_PROXY ?= proxyURL.split(' ')[1]
+            process.env.HTTPS_PROXY ?= "http://#{proxyURL.split(' ')[1]}"
 
         app.resolveProxy 'http://plus.google.com', (proxyURL) ->
             return if proxyURL is 'DIRECT'
-            process.env.HTTP_PROXY ?= proxyURL.split(' ')[1]
+            process.env.HTTP_PROXY ?= "http://#{proxyURL.split(' ')[1]}"
 
     # Create the browser window.
     mainWindow = new BrowserWindow {

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -57,11 +57,15 @@ app.on 'ready', ->
 
     setImmediate ->
 
-        app.resolveProxy 'http://google.com', (proxyURL) ->
-            process.env.HTTP_PROXY ?= proxyURL
+        # Format of proxyURL is either "DIRECT" or "PROXY 127.0.0.1:8888"
 
         app.resolveProxy 'https://google.com', (proxyURL) ->
-            process.env.HTTPS_PROXY ?= proxyURL
+            return if proxyURL is 'DIRECT'
+            process.env.HTTPS_PROXY ?= proxyURL.split(' ')[1]
+
+        app.resolveProxy 'http://google.com', (proxyURL) ->
+            return if proxyURL is 'DIRECT'
+            process.env.HTTP_PROXY ?= proxyURL.split(' ')[1]
 
     # Create the browser window.
     mainWindow = new BrowserWindow {

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -56,16 +56,21 @@ wait = (t) -> Q.Promise (rs) -> setTimeout rs, t
 app.on 'ready', ->
 
     setImmediate ->
+        proxiesReturned = 0
 
         # Format of proxyURL is either "DIRECT" or "PROXY 127.0.0.1:8888"
 
         app.resolveProxy 'https://plus.google.com', (proxyURL) ->
-            return if proxyURL is 'DIRECT'
-            process.env.HTTPS_PROXY ?= "http://#{proxyURL.split(' ')[1]}"
+            proxiesReturned++
+            unless proxyURL is 'DIRECT'
+                process.env.HTTPS_PROXY ?= "http://#{proxyURL.split(' ')[1]}"
+            doFirstConnection() if proxiesReturned is 2
 
         app.resolveProxy 'http://plus.google.com', (proxyURL) ->
-            return if proxyURL is 'DIRECT'
-            process.env.HTTP_PROXY ?= "http://#{proxyURL.split(' ')[1]}"
+            proxiesReturned++
+            unless proxyURL is 'DIRECT'
+                process.env.HTTP_PROXY ?= "http://#{proxyURL.split(' ')[1]}"
+            doFirstConnection() if proxiesReturned is 2
 
     # Create the browser window.
     mainWindow = new BrowserWindow {
@@ -103,15 +108,17 @@ app.on 'ready', ->
 
     # counter for reconnects
     reconnectCount = 0
-    # first connect
-    reconnect().then ->
-        console.log 'connected', reconnectCount
-        # on first connect, send init, after that only resync
-        if reconnectCount == 0
-            sendInit()
-        else
-            syncrecent()
-        reconnectCount++
+
+    doFirstConnection = ->
+        # first connect
+        reconnect().then ->
+            console.log 'connected', reconnectCount
+            # on first connect, send init, after that only resync
+            if reconnectCount == 0
+                sendInit()
+            else
+                syncrecent()
+            reconnectCount++
 
     # client deals with window sizing
     mainWindow.on 'resize', (ev) -> ipcsend 'resize', mainWindow.getSize()


### PR DESCRIPTION
This is untested as, for some reason, the compiled Electron app produced by ./deploy.sh refuses to run on my laptop. No idea why! That is a problem for another day.

There's the potential for a race condition here if the app attempts to communicate before the resolveProxy calls return. They should complete pretty quickly, however, and any errors will hopefully be ironed out by the retry logic. If there's a more intelligent place to move the calls to to ensure they execute before any network traffic is attempted, by all means do so.

Ref #3 