### PR TITLE
Window Icon

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -2,6 +2,7 @@ gulp   = require 'gulp'
 coffee = require 'gulp-coffee'
 less   = require 'gulp-less'
 rimraf     = require 'rimraf'
+path       = require 'path'
 fs         = require 'fs'
 gutil      = require 'gulp-util'
 sourcemaps = require 'gulp-sourcemaps'
@@ -10,6 +11,7 @@ install    = require 'gulp-install'
 concat     = require 'gulp-concat'
 autoReload = require 'gulp-auto-reload'
 changed    = require 'gulp-changed'
+rename     = require 'gulp-rename'
 
 outapp = './app'
 outui  = outapp + '/ui'
@@ -20,6 +22,7 @@ paths =
   coffee:  './src/**/*.coffee'
   html:    './src/**/*.html'
   images:  './src/**/images/*.*'
+  icons:   './src/icons'
   less:    './src/**/*.less'
   css:     './src/**/*.css'
   fonts:   ['./src/**/*.eot', './src/**/*.svg',
@@ -66,6 +69,20 @@ gulp.task 'images', ->
     .pipe gulp.dest outapp
 
 
+gulp.task 'icons', ->
+  nameMap =
+    'icon_016.png': 'icon.png'
+    'icon_032.png': 'icon@2.png'
+    'icon_048.png': 'icon@3.png'
+    'icon_128.png': 'icon@8.png'
+    'icon_256.png': 'icon@16.png'
+    'icon_512.png': 'icon@32.png'
+
+  Object.keys(nameMap).forEach (name) ->
+    gulp.src path.join paths.icons, name
+      .pipe rename nameMap[name]
+      .pipe gulp.dest path.join outapp, 'icons'
+
 # compile less
 gulp.task 'less', ->
   gulp.src paths.less
@@ -103,7 +120,7 @@ gulp.task 'reloader', ->
 gulp.task 'clean', (cb) ->
     rimraf outapp, cb
 
-gulp.task 'default', ['package', 'coffee', 'html', 'images', 'less', 'fontello']
+gulp.task 'default', ['package', 'coffee', 'html', 'images', 'icons', 'less', 'fontello']
 
 gulp.task 'watch', ['default', 'reloader', 'html'], ->
   # watch to rebuild

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-concat": "^2.5.2",
     "gulp-install": "^0.4.0",
     "gulp-less": "^3.0.3",
+    "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.5",
     "mocha": "^2.2.5",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -70,7 +70,6 @@ app.on 'ready', ->
 #        unless proxyURL is 'DIRECT'
 #            process.env.HTTP_PROXY ?= "http://#{proxyURL.split(' ')[1]}"
 #        doFirstConnection() if proxiesReturned is 2
-    doFirstConnection()
     # The above should be uncommented as soon as we upgrade to a version of Electron that incorporates https://github.com/atom/electron/pull/2054
 
     # Create the browser window.
@@ -79,7 +78,7 @@ app.on 'ready', ->
         height: 590
         "min-width": 620
         "min-height": 420
-        icon: path.join __dirname 'icons' 'icon.png'
+        icon: path.join __dirname, 'icons', 'icon.png'
     }
 
     # and load the index.html of the app. this may however be yanked
@@ -121,6 +120,8 @@ app.on 'ready', ->
             else
                 syncrecent()
             reconnectCount++
+
+    doFirstConnection()
 
     # client deals with window sizing
     mainWindow.on 'resize', (ev) -> ipcsend 'resize', mainWindow.getSize()

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -79,6 +79,7 @@ app.on 'ready', ->
         height: 590
         "min-width": 620
         "min-height": 420
+        icon: path.join __dirname 'icons' 'icon.png'
     }
 
     # and load the index.html of the app. this may however be yanked


### PR DESCRIPTION
This copies the icons in to the app directory (in gulp) and uses them as the window icon. It should work on all platforms but I have only tested it on Linux.

I had to move `doFirstConnection` further down as it was called before it was defined and resulted in a crash.