### PR TITLE
Extend .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ indent_style = space
 [*.coffee]
 indent_size = 4
 
-[{gulpfile.coffee,package.json,.travis.yml}]
+[{package.json,.travis.yml}]
 indent_size = 2
 
 [*.md]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,22 @@
+root = true
+
+[*]
+
+charset = utf-8
+end_of_line = lf
+
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+indent_style = space
+
 # 4 space indentation
 [*.coffee]
-indent_style = space
 indent_size = 4
+
+[{gulpfile.coffee,package.json,.travis.yml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 2

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -47,8 +47,8 @@ gulp.task 'coffee', ->
         .pipe sourcemaps.init()
         .pipe coffee()
         .on 'error', (e) ->
-                console.log e.toString()
-                @emit 'end'
+            console.log e.toString()
+            @emit 'end'
         .pipe sourcemaps.write()
 #        .pipe changed outapp
         .pipe gulp.dest outapp

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -1,6 +1,6 @@
-gulp   = require 'gulp'
-coffee = require 'gulp-coffee'
-less   = require 'gulp-less'
+gulp       = require 'gulp'
+coffee     = require 'gulp-coffee'
+less       = require 'gulp-less'
 rimraf     = require 'rimraf'
 path       = require 'path'
 fs         = require 'fs'
@@ -17,41 +17,41 @@ outapp = './app'
 outui  = outapp + '/ui'
 
 paths =
-  README:  './README.md'
-  package: './package.json'
-  coffee:  './src/**/*.coffee'
-  html:    './src/**/*.html'
-  images:  './src/**/images/*.*'
-  icons:   './src/icons'
-  less:    './src/**/*.less'
-  css:     './src/**/*.css'
-  fonts:   ['./src/**/*.eot', './src/**/*.svg',
-            './src/**/*.ttf', './src/**/*.woff']
+    README:  './README.md'
+    package: './package.json'
+    coffee:  './src/**/*.coffee'
+    html:    './src/**/*.html'
+    images:  './src/**/images/*.*'
+    icons:   './src/icons'
+    less:    './src/**/*.less'
+    css:     './src/**/*.css'
+    fonts:   ['./src/**/*.eot', './src/**/*.svg',
+              './src/**/*.ttf', './src/**/*.woff']
 
 # setup package stuff (README, package.json)
 gulp.task 'package', ->
-  gulp.src paths.README
-#    .pipe changed outapp
-    .pipe gulp.dest outapp
+    gulp.src paths.README
+#        .pipe changed outapp
+        .pipe gulp.dest outapp
 
-  # install runtime deps
-  gulp.src paths.package
-#    .pipe changed outapp
-    .pipe gulp.dest outapp
-    .pipe install(production:true)
+    # install runtime deps
+    gulp.src paths.package
+#        .pipe changed outapp
+        .pipe gulp.dest outapp
+        .pipe install(production:true)
 
 
 # compile coffeescript
 gulp.task 'coffee', ->
-  gulp.src paths.coffee
-    .pipe sourcemaps.init()
-    .pipe coffee()
-    .on 'error', (e) ->
-        console.log e.toString()
-        @emit 'end'
-    .pipe sourcemaps.write()
-#    .pipe changed outapp
-    .pipe gulp.dest outapp
+    gulp.src paths.coffee
+        .pipe sourcemaps.init()
+        .pipe coffee()
+        .on 'error', (e) ->
+                console.log e.toString()
+                @emit 'end'
+        .pipe sourcemaps.write()
+#        .pipe changed outapp
+        .pipe gulp.dest outapp
 
 
 # reloader will inject <script> tag
@@ -59,41 +59,41 @@ htmlInject = -> gutil.noop()
 
 # copy .html-files
 gulp.task 'html', ->
-  gulp.src paths.html
-    .pipe htmlInject()
-    .pipe gulp.dest outapp
+    gulp.src paths.html
+        .pipe htmlInject()
+        .pipe gulp.dest outapp
 
 # copy images
 gulp.task 'images', ->
-  gulp.src paths.images
-    .pipe gulp.dest outapp
+    gulp.src paths.images
+        .pipe gulp.dest outapp
 
 
 gulp.task 'icons', ->
-  nameMap =
-    'icon_016.png': 'icon.png'
-    'icon_032.png': 'icon@2.png'
-    'icon_048.png': 'icon@3.png'
-    'icon_128.png': 'icon@8.png'
-    'icon_256.png': 'icon@16.png'
-    'icon_512.png': 'icon@32.png'
+    nameMap =
+        'icon_016.png': 'icon.png'
+        'icon_032.png': 'icon@2.png'
+        'icon_048.png': 'icon@3.png'
+        'icon_128.png': 'icon@8.png'
+        'icon_256.png': 'icon@16.png'
+        'icon_512.png': 'icon@32.png'
 
-  Object.keys(nameMap).forEach (name) ->
-    gulp.src path.join paths.icons, name
-      .pipe rename nameMap[name]
-      .pipe gulp.dest path.join outapp, 'icons'
+    Object.keys(nameMap).forEach (name) ->
+        gulp.src path.join paths.icons, name
+            .pipe rename nameMap[name]
+            .pipe gulp.dest path.join outapp, 'icons'
 
 # compile less
 gulp.task 'less', ->
-  gulp.src paths.less
-    .pipe sourcemaps.init()
-    .pipe less()
-    .on 'error', (e) ->
-        console.log e
-        @emit 'end'
-    .pipe concat('ui/app.css')
-    .pipe sourcemaps.write()
-    .pipe gulp.dest outapp
+    gulp.src paths.less
+        .pipe sourcemaps.init()
+        .pipe less()
+        .on 'error', (e) ->
+            console.log e
+            @emit 'end'
+        .pipe concat('ui/app.css')
+        .pipe sourcemaps.write()
+        .pipe gulp.dest outapp
 
 
 # fontello/css
@@ -103,18 +103,18 @@ gulp.task 'fontello', ->
 
 
 gulp.task 'reloader', ->
-  # create an auto reload server instance
-  reloader = autoReload()
+    # create an auto reload server instance
+    reloader = autoReload()
 
-  # copy the client side script
-  reloader.script()
-    .pipe gulp.dest outui
+    # copy the client side script
+    reloader.script()
+        .pipe gulp.dest outui
 
-  # inject scripts in html
-  htmlInject = reloader.inject
+    # inject scripts in html
+    htmlInject = reloader.inject
 
-  # watch rebuilt stuff
-  gulp.watch "#{outui}/**/*", reloader.onChange
+    # watch rebuilt stuff
+    gulp.watch "#{outui}/**/*", reloader.onChange
 
 
 gulp.task 'clean', (cb) ->
@@ -123,6 +123,6 @@ gulp.task 'clean', (cb) ->
 gulp.task 'default', ['package', 'coffee', 'html', 'images', 'icons', 'less', 'fontello']
 
 gulp.task 'watch', ['default', 'reloader', 'html'], ->
-  # watch to rebuild
-  sources = (v for k, v of paths)
-  gulp.watch sources, ['default']
+    # watch to rebuild
+    sources = (v for k, v of paths)
+    gulp.watch sources, ['default']


### PR DESCRIPTION
I've added encoding and line endling settings to .editorconfig. Also added indentation size for package.json and .travis.yml. Despite the other coffeescript code using 4 spaces I saw that gulpfile.coffee uses 2 spaces so I've also added that.