### PR TITLE
Use Electron v0.27.3 because of a copy paste issue in v0.28

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,14 +5,14 @@ for dep in curl unzip sed; do
   test ! $(which $dep) && echo "ERROR: missing $dep" && exit 1
 done
 
-ELECTRON_VERSION="0.28.1"
+ELECTRON_VERSION="0.27.3"
 PLATFORMS=("darwin-x64" "linux-ia32" "linux-x64" "win32-ia32" "win32-x64")
 
 mkdir -p dist
 cd dist
 for PLATFORM in ${PLATFORMS[*]}; do
     rm -rf $PLATFORM
-    echo "https://github.com/atom/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-$PLATFORM.zip"    
+    echo "https://github.com/atom/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-$PLATFORM.zip"
     test ! -f electron-v$ELECTRON_VERSION-$PLATFORM.zip && \
     curl -LO https://github.com/atom/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-$PLATFORM.zip
     unzip -o electron-v$ELECTRON_VERSION-$PLATFORM.zip -d $PLATFORM

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "^2.3.0",
     "coffee-script": "^1.9.2",
-    "electron-prebuilt": "^0.27.1",
+    "electron-prebuilt": "0.27.3",
     "gulp": "^3.8.11",
     "gulp-auto-reload": "0.1.0",
     "gulp-changed": "^1.2.1",


### PR DESCRIPTION
This is supposed to fix #27 temporarily.