### PR TITLE
YakYak to the tray

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "autosize": "^3.0.8",
     "hangupsjs": "^1.0.1",
     "moment": "^2.10.3",
+	"nconf": "^0.7.2",
     "node-notifier": "^4.2.3",
     "notr": "^1.1.2",
     "q": "^1.4.0",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -107,7 +107,7 @@ app.on 'ready', ->
         { label: 'Hide/show', click: toggleWindowVisible }
         { label: 'Quit', click: quit}
     ]
-    tray.setToolTip 'YakYak - Hangouts client'
+    tray.setToolTip 'Yakyak - Hangouts client'
     tray.setContextMenu contextMenu
 
     # and load the index.html of the app. this may however be yanked

--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -19,8 +19,20 @@ hr'.split(' '))...
 {applayout}       = require './views'
 {viewstate, conv} = require './models'
 
-# install menu
-require('./views/menu')(viewstate)
+config = new(require './config')
+console.log config
+
+# load menu relevant config flags
+config.get 'minimizetotray'
+.then (minimizetotray) ->
+    viewstate.setMinimizeToTray minimizetotray
+    config.get 'startminimized'
+.then (startminimized) ->
+    viewstate.setStartMinimized startminimized
+    # install menu
+    require('./views/menu')(viewstate)
+
+config.set 'test', false
 
 # tie layout to DOM
 document.body.appendChild applayout.el

--- a/src/ui/config.coffee
+++ b/src/ui/config.coffee
@@ -1,0 +1,19 @@
+Q = require 'q'
+
+module.exports = class Config
+    constructor: () ->
+        @listeners = {}
+        @idgen = 0
+        @ipc = require 'ipc'
+        @ipc.on "returngetconfig", (id, value) =>
+            callback = @listeners[id]
+            callback? value
+            delete @listeners[id]
+
+    get: (key) => Q.Promise (rs) =>
+        id = @idgen++
+        @ipc.send 'getconfig', id, key
+        @listeners[id] = rs
+
+    set: (key, value) =>
+        @ipc.send 'setconfig', key, value

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -5,6 +5,8 @@ ipc    = require 'ipc'
 {entity, conv, viewstate, userinput, connection, convsettings, notify} = require './models'
 {throttle, later, isImg} = require './util'
 
+config = new(require './config')
+
 'connecting connected connect_failed'.split(' ').forEach (n) ->
     handle n, -> connection.setState n
 
@@ -296,11 +298,19 @@ handle 'unreadtotal', (total, orMore) ->
 handle 'showconvthumbs', (doshow) ->
     viewstate.setShowConvThumbs doshow
 
+handle 'minimizetotray', (value) ->
+    viewstate.setMinimizeToTray value
+    config.set 'minimizetotray', value
+
+handle 'startminimized', (value) ->
+    viewstate.setStartMinimized value
+    config.set 'startminimized', value
+
 handle 'devtools', ->
     remote.getCurrentWindow().openDevTools detach:true
 
 handle 'quit', ->
-    remote.require('app').quit()
+    ipc.send 'quit'
 
 handle 'togglefullscreen', ->
     ipc.send 'togglefullscreen'

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -19,6 +19,8 @@ module.exports = exp = {
     size: tryparse(localStorage.size ? "[940, 600]")
     pos: tryparse(localStorage.pos ? "[100, 100]")
     showConvThumbs: tryparse(localStorage.showConvThumbs)
+    minimizeToTray: null
+    startMinimized: null
 
     setState: (state) ->
         return if @state == state
@@ -115,6 +117,14 @@ module.exports = exp = {
         return if @showConvThumbs == doshow
         @showConvThumbs = localStorage.showConvThumbs = doshow
         updated 'viewstate'
+
+    setMinimizeToTray: (value) ->
+        return if @minimizeToTray == value
+        @minimizeToTray = value
+
+    setStartMinimized: (value) ->
+        return if @startMinimized == value
+        @startMinimized = value
 
 }
 

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -73,10 +73,10 @@ templateOsx = (viewstate) -> [{
 templateOthers = (viewstate) -> [{
     label: 'Yakyak'
     submenu: [
-        { label: 'Open Inspector', accelerator: 'Command+Alt+I', click: -> action 'devtools' }
+        { label: 'Open Inspector', accelerator: 'Control+Alt+I', click: -> action 'devtools' }
         { type: 'separator' }
         { label: 'Logout', click: -> action 'logout' }
-        { label: 'Quit', accelerator: 'Command+Q', click: -> action 'quit' }
+        { label: 'Quit', accelerator: 'Control+Q', click: -> action 'quit' }
     ]}, {
     label: 'View'
     submenu: [
@@ -87,7 +87,7 @@ templateOthers = (viewstate) -> [{
             click: (it) -> action 'showconvthumbs', it.checked
         }, {
             label: 'Enter Full Screen',
-            accelerator: 'Command+Control+F',
+            accelerator: 'Control+Control+F',
             click: -> action 'togglefullscreen'
         }, {
             label: 'Previous Conversation',

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -14,6 +14,9 @@ templateOsx = (viewstate) -> [{
         { type: 'separator' }
         { label: 'Open Inspector', accelerator: 'Command+Alt+I', click: -> action 'devtools' }
         { type: 'separator' }
+        { type:'checkbox', label: 'Keep running in the system tray when closed', checked: viewstate.minimizeToTray, click: (it) -> action 'minimizetotray', it.checked }
+        { type:'checkbox', label: 'Start minimized in the system tray', checked: viewstate.startMinimized, click: (it) -> action 'startminimized', it.checked }
+        { type: 'separator' }
         { label: 'Logout', click: -> action 'logout' }
         { label: 'Quit', accelerator: 'Command+Q', click: -> action 'quit' }
     ]},{
@@ -74,6 +77,9 @@ templateOthers = (viewstate) -> [{
     label: 'Yakyak'
     submenu: [
         { label: 'Open Inspector', accelerator: 'Control+Alt+I', click: -> action 'devtools' }
+        { type: 'separator' }
+        { type:'checkbox', label: 'Keep running in the system tray when closed', checked: viewstate.minimizeToTray, click: (it) -> action 'minimizetotray', it.checked }
+        { type:'checkbox', label: 'Start minimized in the system tray', checked: viewstate.startMinimized, click: (it) -> action 'startminimized', it.checked }
         { type: 'separator' }
         { label: 'Logout', click: -> action 'logout' }
         { label: 'Quit', accelerator: 'Control+Q', click: -> action 'quit' }


### PR DESCRIPTION
Like discussed in #43 I've added a basic implementation, which offers the following features.
>
* The minimize button in the window title bar minimizes the window to the taskbar just like any other window.
* Clicking the tray icon toggles window visibility and when hidden it also disappears from the task bar. When shown it also reappears in the task bar.
* There is an setting/option whether to just minimize to tray when closing the window (through "×" button in the window title bar), or whether to actually exit the app. It's often labeled as "Keep running in the system tray when closed". Minimize to tray is usually the default.
* Right-clicking the tray icon usually opens a context menu that offers additional functionality including showing the window if it's hidden, hiding it if it's visible, and actually exiting the app.

(Quoted from @maxkueng)

I have only tested my changes on windows and I'm completely new to coffeescript, nodejs and electron, please take this into consideration when looking over my code.