### PR TITLE
Hide windows instead of close for OS X

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -45,7 +45,15 @@ mainWindow = null
 
 # Quit when all windows are closed.
 app.on 'window-all-closed', ->
-    app.quit() # if (process.platform != 'darwin')
+    app.quit() if (process.platform != 'darwin')
+
+# For OSX show window main window if we've hidden it.
+app.on 'activate-with-no-open-windows', ->
+    mainWindow.show() if (process.platform == 'darwin')
+
+# If we're actually trying to close the app set it to force close
+app.on 'before-quit', ->
+    mainWindow.forceClose = true
 
 loadAppWindow = ->
     mainWindow.loadUrl 'file://' + __dirname + '/ui/index.html'
@@ -278,6 +286,9 @@ app.on 'ready', ->
             ipcsend n, e
 
 
-    # Emitted when the window is closed.
-    mainWindow.on 'closed', ->
-        mainWindow = null
+    # Emitted when the window is closed, for OSX only hides the window if we're not force closing.
+    mainWindow.on 'close', (event) ->
+        mainWindow = null if (process.platform != 'darwin')
+        return if mainWindow.forceClose || process.platform != 'darwin'
+        event.preventDefault()
+        mainWindow.hide()


### PR DESCRIPTION
On OS X: Closing the main windows no longer closes the app and simply hides the main windows.
 
Clicking on the dock icon now unhides the window if it's hidden. Closing of the app is now only accomplished through the menu bar or right clicking on the dock icon.

There is no issue for this and I'm not sure if anyone else thinks this is how window management should work (though I suspect from the comment on the old line 48 that someone does) but here it is if you guys want it. OS X only as it's what I use, though I could test elsewhere if needed. Else, please ignore me and have a nice day!

-Alex