### PR TITLE
workaround fixing double clipboard content on paste

### DIFF
--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -62,8 +62,10 @@ module.exports = view (models) ->
                     if e.keyIdentifier is "Down" then historyWalk e.target, +1
             action 'lastkeydown', Date.now() unless isAltCtrlMeta(e)
         , onpaste: (e) ->
-            if not clipboard.readImage().isEmpty() and not clipboard.readText()
-              action 'onpasteimage'
+            setTimeout () ->
+                if not clipboard.readImage().isEmpty() and not clipboard.readText()
+                    action 'onpasteimage'
+            , 2
         button title:'Attach image', onclick: (ev) ->
             document.getElementById('attachFile').click()
         , ->


### PR DESCRIPTION
Solves #27 - tested only on Manjaro Linux. I believe it will work on other Arch-based distributions.

The error occurs because two onpaste events are fired. 

I am neither JS nor CoffeeScript developer and I know this is a hideous solution to the problem but with my limited knowledge it must be sufficient. I hope that after discovering the issue someone will fix it in a better way, and this will be used as a temporary solution by those who suffer from double content paste.