### PR TITLE
Reset zoom

### DIFF
--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -317,7 +317,10 @@ handle 'togglefullscreen', ->
     ipc.send 'togglefullscreen'
 
 handle 'zoom', (step) ->
-    viewstate.setZoom (parseFloat(document.body.style.zoom) or 1.0) + step
+    if step?
+        return viewstate.setZoom (parseFloat(document.body.style.zoom) or 1.0) + step
+
+    viewstate.setZoom 1
 
 handle 'logout', ->
     ipc.send 'logout'

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -60,6 +60,10 @@ templateOsx = (viewstate) -> [{
             label: 'Zoom Out',
             accelerator: 'Command+-',
             click: -> action 'zoom', -0.25
+        }, {
+            label: 'Reset Zoom',
+            accelerator: 'Command+0',
+            click: -> action 'zoom'
         }
     ]},{
     label: 'Window',
@@ -132,6 +136,10 @@ templateOthers = (viewstate) -> [{
             label: 'Zoom Out',
             accelerator: 'Control+-',
             click: -> action 'zoom', -0.25
+        }, {
+            label: 'Reset Zoom',
+            accelerator: 'Control+0',
+            click: -> action 'zoom'
         }
     ]}
 ]


### PR DESCRIPTION
Adds the ability to reset the zoom back to "normal" with `Control+0` on Linux and Windos, or `Command+0` on OS X.