### PR TITLE
Upgrade Electron to v0.34.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "coffee-script": "^1.9.2",
-    "electron-prebuilt": "^0.30.1",
+    "electron-prebuilt": "0.34.1",
     "gulp": "^3.8.11",
     "gulp-auto-reload": "0.1.0",
     "gulp-changed": "^1.2.1",


### PR DESCRIPTION
Seems to work on Linux. Can somebody try it on OS X and Windows? I went through the change logs since 0.30.1 and there aren't any API deprecations that would affect us.

Let's hope this makes some things better.