### PR TITLE
Rename Yakyak to YakYak (fixes #71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-yakyak
+YakYak
 ======
 
 [![Build Status](https://travis-ci.org/yakyak/yakyak.svg)](https://travis-ci.org/yakyak/yakyak) [![Gitter](https://d378bf3rn661mp.cloudfront.net/gitter.svg)](https://gitter.im/yakyak/yakyak)
@@ -39,9 +39,9 @@ What doesn't it do (yet?):
 
 * Have a serious icon (this is being adressed)
 
-![yakyak](https://cloud.githubusercontent.com/assets/227204/8255223/b6409032-169e-11e5-8953-488413b305b4.png)
+![YakYak](https://cloud.githubusercontent.com/assets/227204/8255223/b6409032-169e-11e5-8953-488413b305b4.png)
 
-![yakyak with thumbs](https://cloud.githubusercontent.com/assets/227204/8255540/d922d252-16a0-11e5-86b2-bfec901bbdbc.png)
+![YakYak with thumbs](https://cloud.githubusercontent.com/assets/227204/8255540/d922d252-16a0-11e5-86b2-bfec901bbdbc.png)
 
 ## Credits
 
@@ -87,5 +87,5 @@ $ electron app
 
 - `src/`: is where sources live
 - `src/ui/`: holds renderer code (client side)
-- `Yakyak.app/`: is where the app is built
-- `Yakyak.app/Contents/Resources/app/`: specifically all is compiled to here
+- `YakYak.app/`: is where the app is built
+- `YakYak.app/Contents/Resources/app/`: specifically all is compiled to here

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,24 +13,24 @@ mkdir -p dist
 cd dist
 for PLATFORM in ${PLATFORMS[*]}; do
     rm -rf $PLATFORM
-    echo "https://github.com/atom/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-$PLATFORM.zip"    
+    echo "https://github.com/atom/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-$PLATFORM.zip"
     test ! -f electron-v$ELECTRON_VERSION-$PLATFORM.zip && \
     curl -LO https://github.com/atom/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-$PLATFORM.zip
     unzip -o electron-v$ELECTRON_VERSION-$PLATFORM.zip -d $PLATFORM
 done
 
 cd darwin-x64
-mv Electron.app Yakyak.app
-defaults write $(pwd)/Yakyak.app/Contents/Info.plist CFBundleDisplayName -string "Yakyak"
-defaults write $(pwd)/Yakyak.app/Contents/Info.plist CFBundleExecutable -string "Yakyak"
-defaults write $(pwd)/Yakyak.app/Contents/Info.plist CFBundleIdentifier -string "com.github.yakyak"
-defaults write $(pwd)/Yakyak.app/Contents/Info.plist CFBundleName -string "Yakyak"
-defaults write $(pwd)/Yakyak.app/Contents/Info.plist CFBundleVersion -string "$VERSION"
-plutil -convert xml1 $(pwd)/Yakyak.app/Contents/Info.plist
-mv Yakyak.app/Contents/MacOS/Electron Yakyak.app/Contents/MacOS/Yakyak
-cp -R ../../app Yakyak.app/Contents/Resources/app
-cp ../../src/icons/atom.icns Yakyak.app/Contents/Resources/atom.icns
-zip -r ../yakyak-osx.app.zip Yakyak.app
+mv Electron.app YakYak.app
+defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleDisplayName -string "YakYak"
+defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleExecutable -string "YakYak"
+defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleIdentifier -string "com.github.yakyak"
+defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleName -string "YakYak"
+defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleVersion -string "$VERSION"
+plutil -convert xml1 $(pwd)/YakYak.app/Contents/Info.plist
+mv YakYak.app/Contents/MacOS/Electron YakYak.app/Contents/MacOS/YakYak
+cp -R ../../app YakYak.app/Contents/Resources/app
+cp ../../src/icons/atom.icns YakYak.app/Contents/Resources/atom.icns
+zip -r ../yakyak-osx.app.zip YakYak.app
 cd ..
 
 cd win32-ia32

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -118,7 +118,7 @@ app.on 'ready', ->
             { label: 'Hide/show', click: toggleWindowVisible }
             { label: 'Quit', click: quit}
         ]
-        tray.setToolTip 'Yakyak - Hangouts client'
+        tray.setToolTip 'YakYak - Hangouts client'
         tray.setContextMenu contextMenu
 
         # Emitted when the tray icon is clicked

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Yakyak</title>
+    <title>YakYak</title>
     <link rel="stylesheet" href="app.css">
     <link rel="stylesheet" href="css/fontello/css/fontello.css">
     <link rel="stylesheet" href="css/fontello/css/animation.css">

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -2,7 +2,7 @@ remote = require 'remote'
 Menu = remote.require 'menu'
 
 templateOsx = (viewstate) -> [{
-    label: 'Yakyak'
+    label: 'YakYak'
     submenu: [
         { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' }
         { type: 'separator' }
@@ -87,7 +87,7 @@ templateOsx = (viewstate) -> [{
 
 # TODO: find proper windows/linux accelerators
 templateOthers = (viewstate) -> [{
-    label: 'Yakyak'
+    label: 'YakYak'
     submenu: [
         { label: 'Open Inspector', accelerator: 'Control+Alt+I', click: -> action 'devtools' }
         { type: 'separator' }


### PR DESCRIPTION
Renames all occurrences of "Yakyak" to "YakYak" in order to achieve consistent naming and fixes issue #71.

Note that this also affects the name of the ".app" directory on the MAc build which is now called "YakYak.app" instead of "Yakyak.app".