### PR TITLE
Next/Previous keyboard shortcuts for OSX

### DIFF
--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -45,10 +45,12 @@ templateOsx = (viewstate) -> [{
             click: -> action 'togglefullscreen'
         }, {
             label: 'Previous Conversation',
+            accelerator: 'Command+[',
             enabled: viewstate.loggedin
             click: -> action 'selectNextConv', -1
         }, {
             label: 'Next Conversation',
+            accelerator: 'Command+]',
             enabled: viewstate.loggedin
             click: -> action 'selectNextConv', +1
         }, {


### PR DESCRIPTION
Cmd+] and Cmd+[ are great shortcuts on OSX for next/previous conversations. At least in my opinion.

I got used to them back in the day with Proteus, and then moved on to Adium which used the same keyboard shortcuts.