### PR TITLE
WIP: Enable simple tray icon state changes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,31 @@
 #!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOT=$(dirname "${BASH_SOURCE}")
+
+function yakyak::package() {
+  local arch="$1"
+  local src="electron"
+  local dest="yakyak"
+
+  if [[ ! -f "$src" ]]; then
+    echo "Skipping packaging for $arch (source dist not found)"
+    return
+  fi
+
+  if [[ "$arch" =~ win32 ]]; then
+    src="${src}.exe"
+    dest="${dest}.exe"
+  fi
+
+  pushd $arch >/dev/null
+    mv $src $dest
+    cp -R ../../app resources/app
+  popd >/dev/null
+  zip -r yakyak-$arch.zip $arch
+}
 
 for dep in curl unzip sed; do
   echo "checking dependency... $dep"
@@ -7,7 +34,8 @@ done
 
 ELECTRON_VERSION=$(npm list --depth=0 |grep electron-prebuilt | cut -f2 -d@)
 VERSION=$(node -e "console.log(require('./package').version)")
-PLATFORMS=("darwin-x64" "linux-ia32" "linux-x64" "win32-ia32" "win32-x64")
+DEFAULT_PLATFORMS=("darwin-x64" "linux-ia32" "linux-x64" "win32-ia32" "win32-x64")
+PLATFORMS=${PLATFORMS:-$DEFAULT_PLATFORMS}
 
 mkdir -p dist
 cd dist
@@ -33,28 +61,10 @@ cp ../../src/icons/atom.icns YakYak.app/Contents/Resources/atom.icns
 zip -r ../yakyak-osx.app.zip YakYak.app
 cd ..
 
-cd win32-ia32
-mv electron.exe yakyak.exe
-cp -R ../../app resources/app
-cd ..
-zip -r yakyak-win32-ia32.zip win32-ia32
-
-cd win32-x64
-mv electron.exe yakyak.exe
-cp -R ../../app resources/app
-cd ..
-zip -r yakyak-win32-x64.zip win32-x64
-
-cd linux-ia32
-mv electron yakyak
-cp -R ../../app resources/app
-cd ..
-zip -r yakyak-linux-ia32.zip linux-ia32
-
-cd linux-x64
-mv electron yakyak
-cp -R ../../app resources/app
-cd ..
-zip -r yakyak-linux-x64.zip linux-x64
+yakyak::package win32-x64
+yakyak::package win32-ia32
+yakyak::package linux-x64
+yakyak::package linux-ia32
+yakyak::package darwin-x64
 
 cd ..

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -110,7 +110,11 @@ app.on 'ready', ->
     }
 
     # Create the system tray
-    tray = new Tray path.join __dirname, 'icons', 'icon.png'
+    trayIcons = {
+        "read": path.join __dirname, 'icons', 'icon.png'
+        "unread": path.join __dirname, 'icons', 'icon-unread.png'
+    }
+    tray = new Tray trayIcons["read"]
     contextMenu = Menu.buildFromTemplate [
         { label: 'Hide/show', click: toggleWindowVisible }
         { label: 'Quit', click: quit}
@@ -266,9 +270,9 @@ app.on 'ready', ->
     ipc.on 'updatebadge', (ev, value) ->
         app.dock.setBadge(value) if app.dock
         if value > 0
-            tray.setImage path.join __dirname, 'icons', 'icon-unread.png'
+            tray.setImage trayIcons["unread"]
         else
-            tray.setImage path.join __dirname, 'icons', 'icon.png'
+            tray.setImage trayIcons["read"]
 
     ipc.on 'searchentities', (ev, query, max_results) ->
         promise = client.searchentities query, max_results


### PR DESCRIPTION
### :construction: WIP :construction: 
Add a very simple tray icon state change: when there are unread messages, use a distinct tray icon to provide a visual cue.

Fixes #98 

TODO:
- [ ] Better icon (probably depends on #24)
- [ ] Test `deploy.sh` changes on other platforms
- [ ] Get an explanation for the darwin tray exclusion in https://github.com/yakyak/yakyak/commit/ecf7e02df32110b51c4a76a2f8d71a2aba3082ba (cc @maxkueng)