### PR TITLE
Add extra hints in README.md for new developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It is written in coffeescript (nodejs) based on
 ### Setup
 
 ```bash
+$ sudo npm install -g gulp
 $ npm install
 $ gulp
 ```
@@ -76,6 +77,9 @@ $ gulp watch
 ```
 $ electron app
 ```
+
+You might want to put the electron binary on your $PATH or symlink it. npm puts
+it at `node_modules/electron-prebuilt/dist/electron`.
 
 ### Structure
 


### PR DESCRIPTION
Not knowing gulp and electron beforehand, could make it a bit difficult
to start out. It took me quite some fiddling and looking at misleading
error messages to figure out I should have installed `gulp` _before_
running `npm install` (whereas I assumed npm would install it for me).

The electron binary, also, isn't directly available as a command since
npm does not put it on the $PATH for you. So I added a hint to where the
binary is located.