### PR TITLE
allow URLs to break in messages

### DIFF
--- a/src/ui/views/messages.less
+++ b/src/ui/views/messages.less
@@ -52,6 +52,9 @@
                         max-width: 100%;
                         border-radius: 8px;
                     }
+                    a {
+                        word-break: break-word;
+                    }
                     &.conversation_rename,
                     &.membership_change {
                         font-style: italic;


### PR DESCRIPTION
Previously URLs that contained no breaking characters would not wrap.

Before:
![screenshot 2016-01-22 11 58 37](https://cloud.githubusercontent.com/assets/597829/12517164/7d46350a-c0ff-11e5-9f83-9ebf83fcec44.png)

After:
![screenshot 2016-01-22 11 34 12](https://cloud.githubusercontent.com/assets/597829/12517172/822b6cfc-c0ff-11e5-91dd-7b3a1101fc13.png)
