### PR TITLE
Fix window-position restore on non-OS X systems

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -174,7 +174,7 @@ app.on 'ready', ->
 
     # client deals with window sizing
     mainWindow.on 'resize', (ev) -> ipcsend 'resize', mainWindow.getSize()
-    mainWindow.on 'moved',  (ev) -> ipcsend 'moved', mainWindow.getPosition()
+    mainWindow.on 'move',  (ev) -> ipcsend 'move', mainWindow.getPosition()
 
     # whenever it fails, we try again
     client.on 'connect_failed', ->

--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -56,7 +56,7 @@ ipc.on 'getentity:result', (r, data) ->
     action 'addentities', r.entities, data?.add_to_conv
 
 ipc.on 'resize', (dim) -> action 'resize', dim
-ipc.on 'moved', (pos)  -> action 'moved', pos
+ipc.on 'move', (pos)  -> action 'move', pos
 ipc.on 'searchentities:result', (r) ->
   action 'setsearchedentities', r.entity
 ipc.on 'createconversation:result', (c, name) ->

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -162,7 +162,7 @@ handle 'uploadingimage', (spec) ->
 
 handle 'leftresize', (size) -> viewstate.setLeftSize size
 handle 'resize', (dim) -> viewstate.setSize dim
-handle 'moved', (pos) -> viewstate.setPosition pos
+handle 'move', (pos) -> viewstate.setPosition pos
 
 handle 'conversationname', (name) ->
     convsettings.setName name


### PR DESCRIPTION
According to the electron documentation, ```moved``` is an OS X only event. Instead, ```move``` is used on all systems and on OS X it's actually an alias to ```moved```.

https://github.com/atom/electron/blob/master/docs/api/browser-window.md

Fixes #126 