### PR TITLE
[Mac] - Add ability to hide Dock Icon, Minimize when started

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -83,10 +83,21 @@ loadAppWindow = ->
 toggleWindowVisible = ->
     if mainWindow.isVisible() then mainWindow.hide() else mainWindow.show()
 
+toggleDockIcon = ->
+    if nconf.get 'minimizetotray'
+      app.dock.show()
+      nconf.set 'minimizetotray', false
+    else
+      app.dock.hide()
+      nconf.set 'minimizetotray', true
+    saveConfig()
+
 # helper wait promise
 wait = (t) -> Q.Promise (rs) -> setTimeout rs, t
 
 app.on 'ready', ->
+    if nconf.get 'minimizetotray'
+      app.dock.hide()
 
     proxycheck = ->
         todo = [
@@ -115,10 +126,17 @@ app.on 'ready', ->
         "unread": path.join __dirname, 'icons', 'icon-unread.png'
     }
     tray = new Tray trayIcons["read"]
-    contextMenu = Menu.buildFromTemplate [
+
+    templateContextMenu = [
         { label: 'Hide/show', click: toggleWindowVisible }
-        { label: 'Quit', click: quit}
     ]
+
+    if require('os').platform() == 'darwin'
+      templateContextMenu.push { label: 'Toggle Dock Icon Visibility', click: toggleDockIcon }
+
+    templateContextMenu.push { label: 'Quit', click: quit}
+
+    contextMenu = Menu.buildFromTemplate templateContextMenu
     tray.setToolTip 'YakYak - Hangouts client'
     tray.setContextMenu contextMenu
 

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -14,6 +14,8 @@ templateOsx = (viewstate) -> [{
         { type: 'separator' }
         { label: 'Open Inspector', accelerator: 'Command+Alt+I', click: -> action 'devtools' }
         { type: 'separator' }
+        { type:'checkbox', label: 'Start minimized', checked: viewstate.startMinimized, click: (it) -> action 'startminimized', it.checked }
+        { type: 'separator' }
         {
           label: 'Logout',
           click: -> action 'logout'


### PR DESCRIPTION
It looks like there are a few settings that don't exist on Mac but were implemented for Windows.

Namely:
1) Minimize when started. I was able to enable this by just enabling the checkbox.
2) Ability to minimize to tray. On Mac, this would be hiding the dock icon. I implemented this change, and added the setting to the context menu. This setting should probably be moved to a settings in the app, but right now there isn't a settings page. I couldn't put it in the same place as the other settings because when you hide a dock icon, it also hides the menu bar for the app.