### PR TITLE
Made close to tray optional for every system

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -46,22 +46,20 @@ seqreq = require './seqreq'
 mainWindow = null
 
 # No more minimizing to tray, just close it
-readyToClose = false
+global.forceClose = false;
 quit = ->
-    readyToClose = true
+    global.forceClose = true;
     app.quit()
+    return
 
-# Quit when all windows are closed.
-app.on 'window-all-closed', ->
-    app.quit() if (process.platform != 'darwin')
+app.on 'before-quit', ->
+    global.forceClose = true;
+    return
 
 # For OSX show window main window if we've hidden it.
-app.on 'activate-with-no-open-windows', ->
-    mainWindow.show() if (process.platform == 'darwin')
-
-# If we're actually trying to close the app set it to force close
-app.on 'before-quit', ->
-    mainWindow?.forceClose = true
+# https://github.com/electron/electron/blob/master/docs/api/app.md#event-activate-os-x
+app.on 'activate', ->
+    mainWindow.show()
 
 loadAppWindow = ->
     mainWindow.loadUrl 'file://' + __dirname + '/ui/index.html'
@@ -94,7 +92,7 @@ app.on 'ready', ->
         icon: path.join __dirname, 'icons', 'icon.png'
         show: true
     }
-    
+
 
     # and load the index.html of the app. this may however be yanked
     # away if we must do auth.
@@ -119,7 +117,7 @@ app.on 'ready', ->
         # reinstate app window when login finishes
         prom = login(loginWindow)
         .then (rs) ->
-          loginWindow.forceClose = true
+          global.forceClose = true
           loginWindow.close()
           mainWindow.show()
           rs
@@ -321,12 +319,7 @@ app.on 'ready', ->
     # Emitted when the window is actually closed.
     mainWindow.on 'closed', ->
         mainWindow = null
+        # Close the application when we have no main window
+        app.quit()
+        return
 
-    # Emitted when the window is about to close.
-    # For OSX only hides the window if we're not force closing.
-    mainWindow.on 'close', (ev) ->
-        darwinHideOnly = process.platform == 'darwin' and not mainWindow?.forceClose
-
-        if darwinHideOnly
-            ev.preventDefault()
-            mainWindow.hide()

--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -11,6 +11,8 @@ notr.defineStack 'def', 'body', {top:'3px', right:'15px'}
 # init trifl dispatcher
 dispatcher = require './dispatcher'
 
+remote = require 'remote';
+
 # expose some selected tagg functions
 trifl.tagg.expose window, ('ul li div span a i b u s button p label
 input table thead tbody tr td th textarea br pass img h1 h2 h3 h4
@@ -21,7 +23,7 @@ hr'.split(' '))...
 
 require('./views/menu')(viewstate)
 if viewstate.startminimizedtotray
-  require('remote').getCurrentWindow().hide()
+  remote.getCurrentWindow().hide()
 
 # tie layout to DOM
 document.body.appendChild applayout.el
@@ -70,5 +72,23 @@ action 'reqinit'
 # register event listeners for on/offline
 window.addEventListener 'online',  -> action 'wonline', true
 window.addEventListener 'offline', -> action 'wonline', false
+
+# Listen to close and quit events
+window.addEventListener 'beforeunload', (e) ->
+    if remote.getGlobal('forceClose')
+        return
+
+    hide = (
+        # Mac os and the dock have a special relationship
+        (process.platform == 'darwin' && !viewstate.hidedockicon) ||
+        # Handle the close to tray action
+        viewstate.closetotray
+    )
+
+    if hide
+        e.returnValue = false
+        remote.getCurrentWindow().hide()
+    return
+
 # tell the startup state
 action 'wonline', window.navigator.onLine

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -31,7 +31,7 @@ handle 'init', (init) ->
     # ensure there's a selected conv
     unless conv[viewstate.selectedConv]
         viewstate.setSelectedConv conv.list()?[0]?.conversation_id
-    
+
     require('./version').check()
 
 handle 'chat_message', (ev) ->
@@ -101,10 +101,13 @@ handle 'togglewindow', ->
 handle 'togglestartminimizedtotray', ->
     viewstate.setStartMinimizedToTray(not viewstate.startminimizedtotray)
 
+handle 'toggleclosetotray', ->
+    viewstate.setCloseToTray(not viewstate.closetotray)
+
 handle 'showwindow', ->
     mainWindow = remote.getCurrentWindow() # And we hope we don't get another ;)
     mainWindow.show()
-  
+
 sendsetpresence = throttle 10000, ->
     ipc.send 'setpresence'
     ipc.send 'setactiveclient', true, 15

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -24,6 +24,7 @@ module.exports = exp = {
     showtray: tryparse(localStorage.showtray) or false
     hidedockicon: tryparse(localStorage.hidedockicon) or false
     startminimizedtotray: tryparse(localStorage.startminimizedtotray) or false
+    closetotray: tryparse(localStorage.closetotray) or false
 
     setState: (state) ->
         return if @state == state
@@ -130,7 +131,12 @@ module.exports = exp = {
 
     setShowTray: (value) ->
         @showtray = localStorage.showtray = value
-        if not value then @setStartMinimizedToTray(false) else updated 'viewstate'
+
+        if not @showtray
+            @setCloseToTray(false)
+            @setStartMinimizedToTray(false)
+        else
+            updated 'viewstate'
 
     setHideDockIcon: (value) ->
         @hidedockicon = localStorage.hidedockicon = value
@@ -140,7 +146,9 @@ module.exports = exp = {
         @startminimizedtotray = localStorage.startminimizedtotray = value
         updated 'viewstate'
 
-
+    setCloseToTray: (value) ->
+        @closetotray = localStorage.closetotray = !!value
+        updated 'viewstate'
 }
 
 merge exp, STATES

--- a/src/ui/views/trayicon.coffee
+++ b/src/ui/views/trayicon.coffee
@@ -18,7 +18,7 @@ create = () ->
     tray.setToolTip 'YakYak - Hangouts client'
     # Emitted when the tray icon is clicked
     tray.on 'clicked', -> action 'showwindow'
-    
+
 destroy = ->
     tray.destroy() if tray
     tray = null
@@ -30,21 +30,28 @@ update = (unreadCount, viewstate) ->
           label: 'Toggle minimize to tray'
           click: -> action 'togglewindow'
         }
-        
+
         {
           label: "Start minimzed to tray"
           type: "checkbox"
           checked: viewstate.startminimizedtotray
           click: -> action 'togglestartminimizedtotray'
         }
-        
-        { 
+
+        {
+            label: "Close to tray"
+            type: "checkbox"
+            checked: viewstate.closetotray
+            click: -> action 'toggleclosetotray'
+        }
+
+        {
           label: 'Hide Dock icon'
           type: 'checkbox'
           checked: viewstate.hidedockicon
           click: -> action 'togglehidedockicon'
         } if require('os').platform() == 'darwin'
-        
+
         { label: 'Quit', click: -> action 'quit' }
     ])
 
@@ -52,7 +59,7 @@ update = (unreadCount, viewstate) ->
     tray.setContextMenu contextMenu
 
     # update icon
-    try 
+    try
       if unreadCount > 0
           tray.setImage trayIcons["unread"]
       else


### PR DESCRIPTION
Hi there,

So I finally had some time to fix #135 

By default close to tray is off but can be set to on using the tray menu.

When turned on it will use ['beforeunload'](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#event-close) to avoid closing the window expect when quit triggers the custom window event 'quit'.

Let me know what you think.

Cheers,
Warnar
