### PR TITLE
Pull messages sent by self to the right

### DIFF
--- a/src/ui/views/messages.less
+++ b/src/ui/views/messages.less
@@ -15,6 +15,11 @@
         .ugroup {
             margin-top: 17px;
             position: relative;
+            &::after{
+                content: '';
+                display: block;
+                clear: both;
+            }
             .sender {
                 text-decoration: none;
                 font-size: 11px;
@@ -69,8 +74,31 @@
                 .sender {
                 }
                 .umessages {
+                    float: right;
                     //direction: ltr;
                     .message {
+                        background-color: #eee;
+                        border-radius: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        margin-left: 20px;
+                        margin-right: 0px;
+                    }
+                    .message-top {
+                        border-radius: 5px 5px 0px 0px;
+                    }
+                    .message-mid {
+                        border-radius: 0px;
+                    }
+                    .message-bot {
+                        border-radius: 0px 0px 5px 5px;
+                    }
+                }
+            }
+            &.notself {
+                .umessages {
+                    .message {
+                        margin-right: 20px;
                     }
                 }
             }


### PR DESCRIPTION
This matches with the look that hangouts, iMessage, FB chat and
others use that I think most have become accostomed to. I find it
aids reading back through a chat.

Other style notes/changes:
  - Add a slight background color to messages sent by self
  - Round off grouped messages such that they appear as one block
  - Remove name for messages sent by self (redundant, looks funny IMO)
  - Chat heads stay in the left column for quick scanning

I've never used coffescript or less before so if I did anything foolish, feel
free to yell at me and I'll fix.

<img width="411" alt="screen shot 2016-03-24 at 01 49 56" src="https://cloud.githubusercontent.com/assets/339422/14009484/c985f0ca-f162-11e5-81d5-8869452c1d97.png">
