### PR TITLE
break-word in messages to prevent overflow issues

### DIFF
--- a/src/ui/views/messages.less
+++ b/src/ui/views/messages.less
@@ -42,6 +42,7 @@
                     font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif, "NotoColorEmoji";
                     padding-bottom: 5px;
                     white-space: pre-wrap;
+                    word-break: break-word;
                     &.placeholder {
                         opacity: 0.5;
                     }


### PR DESCRIPTION
Without this, long words (read: super long random crap you type with no spaces) break the UI by overflowing.

I patched this just for URLs before, but now I realize it's an issue for normal text as well.