### PR TITLE
Only allow a single running instance

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -45,6 +45,15 @@ seqreq = require './seqreq'
 
 mainWindow = null
 
+# Only allow a single active instance
+shouldQuit = app.makeSingleInstance ->
+    mainWindow.show() if mainWindow
+    return true;
+
+if shouldQuit
+    app.quit();
+    return;
+
 # No more minimizing to tray, just close it
 readyToClose = false
 quit = ->
@@ -94,7 +103,7 @@ app.on 'ready', ->
         icon: path.join __dirname, 'icons', 'icon.png'
         show: true
     }
-    
+
 
     # and load the index.html of the app. this may however be yanked
     # away if we must do auth.


### PR DESCRIPTION
Hi there,

When using YakYak in gnome I have had the problem a couple of times that I started yakyak multiple times because I forgot that it was in the tray.
This PR fixes that by adding [`makeSingleInstance`](https://github.com/electron/electron/blob/v0.37.4/docs/api/app.md#appmakesingleinstancecallback) in combination with [`mainWindow.show`](https://github.com/electron/electron/blob/v0.37.4/docs/api/browser-window.md#winshow).

Cheers,
Warnar