### PR TITLE
fix an issue with jQuery global namespace registration in Login

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -128,6 +128,9 @@ app.on 'ready', ->
             "min-height": 420
             icon: path.join __dirname, 'icons', 'icon.png'
             show: true
+            webPreferences: {
+                nodeIntegration: false
+            }
         }
         mainWindow.hide()
         loginWindow.focus()


### PR DESCRIPTION
Some environments redirect to a third-party site when authenticating to Google (using SAML). In my case, the third-party site had several jQuery plugins implemented which required window.jQuery to be defined. 

See this issue for more information:
https://github.com/electron/electron/issues/254