### PR TITLE
fix jQuery global window namespace registration

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -128,6 +128,9 @@ app.on 'ready', ->
             "min-height": 420
             icon: path.join __dirname, 'icons', 'icon.png'
             show: true
+            webPreferences: {
+                nodeIntegration: false
+            }
         }
         mainWindow.hide()
         loginWindow.focus()


### PR DESCRIPTION
loginWindow is spawned with nodeIntegration set to True. Since
loginWindow will always be reaching out to external servers, we
can set nodeIntegration to False to prevent the 'module' global
namespace variable from being set.

https://github.com/electron/electron/issues/254

Some environments redirect to a third-party site when authenticating to Google (using SAML). In my case, the third-party site had several jQuery plugins implemented which required window.jQuery to be defined.
