### PR TITLE
fix app to exit gracefully when login window closed (#192)

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -129,12 +129,16 @@ app.on 'ready', ->
             icon: path.join __dirname, 'icons', 'icon.png'
             show: true
         }
+
+        loginWindow.on 'closed', quit
+
         mainWindow.hide()
         loginWindow.focus()
         # reinstate app window when login finishes
         prom = login(loginWindow)
         .then (rs) ->
           global.forceClose = true
+          loginWindow.removeAllListeners 'closed'
           loginWindow.close()
           mainWindow.show()
           rs
@@ -339,6 +343,4 @@ app.on 'ready', ->
     # Emitted when the window is actually closed.
     mainWindow.on 'closed', ->
         mainWindow = null
-        # Close the application when we have no main window
-        app.quit()
-        return
+        quit()


### PR DESCRIPTION
Closing the login window before successfully authenticating
will now close the application as expected.

Fix issue #192