### PR TITLE
Use local dependencies & add commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,25 +63,27 @@ It is written in coffeescript (nodejs) based on
 ### Setup
 
 ```bash
-$ sudo npm install -g gulp
 $ npm install
-$ gulp
+$ npm run gulp
 ```
 
 ### Continuous build
 
 ```
-$ gulp watch
+$ npm run gulp watch
 ```
 
 ### Run it
 
 ```
-$ electron app
+$ npm run electron app
 ```
 
-You might want to put the electron binary on your $PATH or symlink it. npm puts
-it at `node_modules/electron-prebuilt/dist/electron`.
+### Build Binaries for Deployment
+
+```
+$ npm run deploy
+```
 
 ### Structure
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Chat client for Google Hangouts",
   "main": "main.js",
   "scripts": {
-    "test": "mocha"
+    "gulp": "gulp",
+    "electron": "electron",
+    "test": "mocha",
+    "deploy": "bash ./deploy.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR removes the need for global project dependencies and updates the documentation in README. Changes outlined below:

- Removes need for global install of Gulp and Electron by using local dependencies
- Add deploy script to npm scripts
- Add documentation for new commands and building binaries

Edit: This addresses question in #204 