### PR TITLE
On resize / move , no update viewstate

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -109,6 +109,7 @@ app.on 'ready', ->
         icon: path.join __dirname, 'icons', 'icon.png'
         show: true
         titleBarStyle: 'hidden-inset' if process.platform is 'darwin'
+        autoHideMenuBar : true unless process.platform is 'darwin'
     }
 
 

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -64,7 +64,7 @@
         flex: 1;
         display: flex;
         flex-direction: column;
-        background: linear-gradient(var(--green), var(--green) var(--headerbarheight), var(--lightgrey) var(--headerbarheight));
+        background: linear-gradient(var(--green), var(--green) ~"calc(var(--headerbarheight) / var(--zoom))", var(--lightgrey) ~"calc(var(--headerbarheight) / var(--zoom))");
         > .main {
             flex: 1;
             overflow-x: hidden;

--- a/src/ui/css/yakyak/convhead.less
+++ b/src/ui/css/yakyak/convhead.less
@@ -1,7 +1,7 @@
 .convhead{
 	width: 100%;
 	position: relative;
-	height: var(--headerbarheight);
+	height: ~"calc(var(--headerbarheight) / var(--zoom))";
 
 	.name{
 		background: var(--green);
@@ -10,15 +10,15 @@
 		width: 100%;
 		display: block;
 		color: var(--white);
-		height: pvar(--headerbarheight)x;
-		line-height: var(--headerbarheight);
-		font-size: 16px;
+		height: ~"calc(var(--headerbarheight) / var(--zoom))";
+		line-height: ~"calc(var(--headerbarheight) / var(--zoom))";
+		font-size: ~"calc(16px / var(--zoom))";
 		font-weight: bold;
 		text-align: center;
 		-webkit-app-region: drag;
 		-webkit-user-select: none;
 		.material-icons{
-			font-size: 13px;
+			font-size: .82em;
 			margin-right: 2px;
 		}
 	}
@@ -30,20 +30,21 @@
 		cursor: pointer;
 		z-index: 2;
 		color: var(--white);
-		line-height: var(--headerbarheight);
-		height: var(--headerbarheight);
+		line-height: ~"calc(var(--headerbarheight) / var(--zoom))";
+		height: ~"calc(var(--headerbarheight) / var(--zoom))";
 		text-align: center;
 		.material-icons{
 			position: relative;
 			top: 7px;
+			font-size: ~"calc(24px / var(--zoom))";
 		}
 	}
 
 	.convoptions{
 		background: var(--white);
 		width: 100%;
-		height: var(--headerbarheight);
-		line-height: var(--headerbarheight);
+		height: ~"calc(var(--headerbarheight) / var(--zoom))";
+		line-height: ~"calc(var(--headerbarheight) / var(--zoom))";
 		position: relative;
 		z-index: 1;
 		border-bottom: 1px solid rgba(0, 0, 0, .1);
@@ -58,8 +59,8 @@
 			display: inline-block;
 			vertical-align: top;
 			color: var(--darkgrey);
-			height: var(--headerbarheight);
-			line-height: var(--headerbarheight);
+			height: ~"calc(var(--headerbarheight) / var(--zoom))";
+			line-height: ~"calc(var(--headerbarheight) / var(--zoom))";
 			width: auto;
 			padding: 0 10px;
 			cursor: pointer;

--- a/src/ui/css/yakyak/listhead.less
+++ b/src/ui/css/yakyak/listhead.less
@@ -1,20 +1,32 @@
 .listhead {
     background: var(--green);
     color: var(--white);
-    height: var(--headerbarheight);
-    line-height: var(--headerbarheight);
+    height: ~"calc(var(--headerbarheight) / var(--zoom))";
+    line-height: ~"calc(var(--headerbarheight) / var(--zoom))";
     position: relative;
     text-align: center;
-    font-size: 16px;
+    font-size: ~"calc(16px / var(--zoom))";
     font-weight: bold;
     -webkit-app-region: drag;
     -webkit-user-select: none;
+    button{
+        background: none;
+        color: var(--white);
+        height: ~"calc(var(--headerbarheight) / var(--zoom))";
+        padding: 0 .5em;
+        position: absolute;
+        left: 0;
+        cursor: pointer;
+        .material-icon{
+            font-size: ~"calc(24px / var(--zoom))";
+        }
+    }
 }
 
 .osx {
     .listhead {
         .listheadlabel {
-            padding-left: 77px;
+            padding-left: ~"calc(77px / var(--zoom))";
             text-align: left;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -106,6 +106,10 @@ handle 'sendmessage', (txt) ->
 handle 'toggleshowtray', ->
     viewstate.setShowTray(not viewstate.showtray)
 
+handle 'togglemenu', ->
+    mainWindow = remote.getCurrentWindow()
+    if mainWindow.isMenuBarVisible() then mainWindow.setMenuBarVisibility(false) else mainWindow.setMenuBarVisibility(true)
+
 handle 'togglehidedockicon', ->
     viewstate.setHideDockIcon(not viewstate.hidedockicon)
 
@@ -353,7 +357,7 @@ handle 'togglefullscreen', ->
 
 handle 'zoom', (step) ->
     if step?
-        return viewstate.setZoom (parseFloat(document.body.style.zoom) or 1.0) + step
+        return viewstate.setZoom (parseFloat(document.body.style.zoom.replace(',', '.')) or 1.0) + step
     viewstate.setZoom 1
 
 handle 'logout', ->

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -92,12 +92,13 @@ module.exports = exp = {
         # updated 'viewstate'
 
     setLeftSize: (size) ->
-        return if @leftSize == size
+        return if @leftSize == size or size < 180
         @leftSize = localStorage.leftSize = size
         updated 'viewstate'
 
     setZoom: (zoom) ->
         @zoom = localStorage.zoom = document.body.style.zoom = zoom
+        document.body.style.setProperty('--zoom', zoom)
 
     setLoggedin: (val) ->
         @loggedin = val

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -84,12 +84,12 @@ module.exports = exp = {
     setSize: (size) ->
         localStorage.size = JSON.stringify(size)
         @size = size
-        updated 'viewstate'
+        # updated 'viewstate'
 
     setPosition: (pos) ->
         localStorage.pos = JSON.stringify(pos)
         @pos = pos
-        updated 'viewstate'
+        # updated 'viewstate'
 
     setLeftSize: (size) ->
         return if @leftSize == size

--- a/src/ui/views/controller.coffee
+++ b/src/ui/views/controller.coffee
@@ -41,6 +41,7 @@ handle 'update:viewstate', ->
         applayout.maininfo null
         applayout.foot null
         document.body.style.zoom = viewstate.zoom
+        document.body.style.setProperty('--zoom', viewstate.zoom)
     else if viewstate.state == viewstate.STATE_NORMAL
         redraw()
         applayout.lfoot controls

--- a/src/ui/views/listhead.coffee
+++ b/src/ui/views/listhead.coffee
@@ -1,2 +1,10 @@
 module.exports = view (models) ->
-	div class:'listheadlabel', "Conversations"
+	div class:'listheadlabel', ->
+		if process.platform isnt 'darwin'
+			button title:'Menu', onclick:togglemenu, ->
+				i class:'material-icons', "menu"
+		span "Conversations"
+
+togglemenu = ->
+	if process.platform isnt 'darwin'
+		action 'togglemenu'


### PR DESCRIPTION
#229 Windows performance issue

It seems like we do not need to update viewstate on these events.
These events fire A LOT when you resize and can hang or crash the app if you do heavy stuff like updating viewstate.

Tested on windows 10, i7 6700k + 32gb ram. Before, app took ~3secs to update view when I tried to resize, and sometimes froze or crashed. Now, it's so smooth :)