### PR TITLE
Hide window on ESC key

### DIFF
--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -109,6 +109,10 @@ handle 'toggleshowtray', ->
 handle 'togglehidedockicon', ->
     viewstate.setHideDockIcon(not viewstate.hidedockicon)
 
+handle 'hideWindow', ->
+    mainWindow = remote.getCurrentWindow() # And we hope we don't get another ;)
+    mainWindow.hide()
+
 handle 'togglewindow', ->
     mainWindow = remote.getCurrentWindow() # And we hope we don't get another ;)
     if mainWindow.isVisible() then mainWindow.hide() else mainWindow.show()

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -87,6 +87,9 @@ module.exports = view (models) ->
                 if (e.metaKey or e.ctrlKey) and e.keyIdentifier == 'Up' then action 'selectNextConv', -1
                 if (e.metaKey or e.ctrlKey) and e.keyIdentifier == 'Down' then action 'selectNextConv', +1
                 unless isModifierKey(e)
+                    if e.keyCode == 27
+                        e.preventDefault()
+                        action 'hideWindow'
                     if e.keyCode == 13
                         e.preventDefault()
                         action 'sendmessage', e.target.value


### PR DESCRIPTION
Alternative shortcut to hide the window. It is not practical every time to use the mouse to hide. Using the ESC key is a fast and intuitive way to hide the window quickly.