### PR TITLE
Fix clicking on notification not focusing the app

### DIFF
--- a/src/ui/views/notifications.coffee
+++ b/src/ui/views/notifications.coffee
@@ -62,7 +62,7 @@ module.exports = (models) ->
             sender: 'com.github.yakyak'
             sound: true
         , (err, res) ->
-          if res?.trim().match(/Activate/)
+          if res?.trim().match(/Activate/i)
             action 'appfocus'
             action 'selectConv', c
             


### PR DESCRIPTION
This is happening on macOS at least because it receives "activate" with
lowercase 'A'.