### PR TITLE
Show main window on focus if closed to tray

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -287,7 +287,10 @@ app.on 'ready', ->
 
     ipc.on 'appfocus', ->
       app.focus()
-      mainWindow.focus()
+      if mainWindow.isVisible()
+        mainWindow.focus()
+      else
+        mainWindow.show()
 
     # no retries, dedupe on conv_id
     ipc.on 'settyping', seqreq (ev, conv_id, v) ->


### PR DESCRIPTION
On Mac, clicking on a notification won't show the app if it is closed to tray.