### PR TITLE
Enable spellchecker

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "hangupsjs": "^1.3.1",
     "moment": "^2.10.3",
     "node-notifier": "^4.2.3",
+    "spellchecker": "^3.3.1",
     "notr": "^1.1.2",
     "q": "^1.4.0",
     "request": "^2.67.0",

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -1,6 +1,7 @@
 Client = require 'hangupsjs'
 remote = require('electron').remote
 ipc    = require('electron').ipcRenderer
+spellchecker = require('spellchecker')
 
 {entity, conv, viewstate, userinput, connection, convsettings, notify} = require './models'
 {throttle, later, isImg} = require './util'
@@ -37,6 +38,10 @@ handle 'init', (init) ->
     ipc.send 'initpresence', entity.list()
 
     require('./version').check()
+
+    spellchecker.setDictionary(navigator.language)
+    require('electron').webFrame.setSpellCheckProvider navigator.language, true, spellCheck: (text) ->
+        spellchecker.isMisspelled(text) != false
 
 handle 'chat_message', (ev) ->
     conv.addChatMessage ev

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -39,9 +39,12 @@ handle 'init', (init) ->
 
     require('./version').check()
 
-    spellchecker.setDictionary(navigator.language)
     require('electron').webFrame.setSpellCheckProvider navigator.language, true, spellCheck: (text) ->
-        spellchecker.isMisspelled(text) != false
+        for dictionary in spellchecker.getAvailableDictionaries()
+            spellchecker.setDictionary(dictionary)
+            if spellchecker.isMisspelled(text) != false
+                return true
+        return false
 
 handle 'chat_message', (ev) ->
     conv.addChatMessage ev


### PR DESCRIPTION
Only works for the system language and underlines misspelled words. It doesn't offer suggestions at the moment.

Fixes #61