### PR TITLE
Use cursor default for convlist

### DIFF
--- a/src/ui/css/yakyak/convlist.less
+++ b/src/ui/css/yakyak/convlist.less
@@ -7,6 +7,7 @@
         color: var(--white);
         text-align: center;
         background-color: var(--darkgrey);
+        cursor: default;
     }
     .starred {
         .conv:last-child {
@@ -39,7 +40,7 @@
         }
         &.selected {
             background: var(--lightgrey);
-            cursor: auto;
+            cursor: default;
             &:before{
                 content: '';
                 display: block;


### PR DESCRIPTION
You should add `cursor: default` to `body` and add custom cursors to elements that need one: text boxes, menu items, conversation list, message input, etc.