### PR TITLE
Deploy to specific platforms

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -19,47 +19,61 @@ for PLATFORM in ${PLATFORMS[*]}; do
     unzip -o electron-v$ELECTRON_VERSION-$PLATFORM.zip -d $PLATFORM
 done
 
-cd darwin-x64
-mv Electron.app YakYak.app
-defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleDisplayName -string "YakYak"
-defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleExecutable -string "YakYak"
-defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleIdentifier -string "com.github.yakyak"
-defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleName -string "YakYak"
-defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleVersion -string "$VERSION"
-plutil -convert xml1 $(pwd)/YakYak.app/Contents/Info.plist
-mv YakYak.app/Contents/MacOS/Electron YakYak.app/Contents/MacOS/YakYak
-cp -R ../../app YakYak.app/Contents/Resources/app
-cp ../../src/icons/icon.icns YakYak.app/Contents/Resources/electron.icns
-zip -r -y -X ../yakyak-osx.app.zip YakYak.app
-# ditto -c -k --rsrc --extattr --keepParent YakYak.app ../yakyak-osx.app.zip
-cd ..
+build_max() {
+  cd darwin-x64
+  mv Electron.app YakYak.app
+  defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleDisplayName -string "YakYak"
+  defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleExecutable -string "YakYak"
+  defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleIdentifier -string "com.github.yakyak"
+  defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleName -string "YakYak"
+  defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleVersion -string "$VERSION"
+  plutil -convert xml1 $(pwd)/YakYak.app/Contents/Info.plist
+  mv YakYak.app/Contents/MacOS/Electron YakYak.app/Contents/MacOS/YakYak
+  cp -R ../../app YakYak.app/Contents/Resources/app
+  cp ../../src/icons/icon.icns YakYak.app/Contents/Resources/electron.icns
+  zip -r -y -X ../yakyak-osx.app.zip YakYak.app
+  # ditto -c -k --rsrc --extattr --keepParent YakYak.app ../yakyak-osx.app.zip
+  cd ..
+}
 
-cd win32-ia32
-mv electron.exe yakyak.exe
-cp -R ../../app resources/app
-cd ..
-zip -r yakyak-win32-ia32.zip win32-ia32
-# ditto -c -k --rsrc --extattr --keepParent win32-ia32 yakyak-win32-ia32.zip
+build_win32_ia32 () {
+  cd win32-ia32
+  mv electron.exe yakyak.exe
+  cp -R ../../app resources/app
+  cd ..
+  zip -r yakyak-win32-ia32.zip win32-ia32
+  # ditto -c -k --rsrc --extattr --keepParent win32-ia32 yakyak-win32-ia32.zip
+}
 
+build_win32_x64 () {
+  cd win32-x64
+  mv electron.exe yakyak.exe
+  cp -R ../../app resources/app
+  cd ..
+  zip -r yakyak-win32-x64.zip win32-x64
+  # ditto -c -k --rsrc --extattr --keepParent win32-x64 yakyak-win32-x64.zip
+}
 
-cd win32-x64
-mv electron.exe yakyak.exe
-cp -R ../../app resources/app
-cd ..
-zip -r yakyak-win32-x64.zip win32-x64
-# ditto -c -k --rsrc --extattr --keepParent win32-x64 yakyak-win32-x64.zip
+build_linux_ia32 () {
+  cd linux-ia32
+  mv electron yakyak
+  cp -R ../../app resources/app
+  cd ..
+  zip -r yakyak-linux-ia32.zip linux-ia32
+  # ditto -c -k --rsrc --extattr --keepParent linux-ia32 yakyak-linux-ia32.zip
+}
 
-cd linux-ia32
-mv electron yakyak
-cp -R ../../app resources/app
-cd ..
-zip -r yakyak-linux-ia32.zip linux-ia32
-# ditto -c -k --rsrc --extattr --keepParent linux-ia32 yakyak-linux-ia32.zip
+build_linux_x64 () {
+  cd linux-x64
+  mv electron yakyak
+  cp -R ../../app resources/app
+  cd ..
+  zip -r yakyak-linux-x64.zip linux-x64
+  # ditto -c -k --rsrc --extattr --keepParent linux-x64 yakyak-linux-x64.zip
+  cd ..
+}
 
-cd linux-x64
-mv electron yakyak
-cp -R ../../app resources/app
-cd ..
-zip -r yakyak-linux-x64.zip linux-x64
-# ditto -c -k --rsrc --extattr --keepParent linux-x64 yakyak-linux-x64.zip
-cd ..
+build_win32_ia32
+build_win32_x64
+build_linux_ia32
+build_linux_x64

--- a/deploy.sh
+++ b/deploy.sh
@@ -44,6 +44,19 @@ else
         PLATFORMS=${ALLPLATFORMS[*]}
         break
         ;;
+      -h|--help|--usage)
+        echo "Usage: bash deploy.sh [platforms]"
+        echo "  platforms:"
+        echo "    --all : all platforms, equivalent to no argument"
+        echo "    --darwin-x64 : Mac OSX 64 bits"
+        echo "    --win32-x64 : Windows 64 bits"
+        echo "    --win32-ia32 : Windows 32 bits"
+        echo "    --linux-x64 : Linux 64 bits"
+        echo "    --linux-ia32 : Linux 32 bits"
+        echo ""
+        echo "  --help or -h or --usage : show this help"
+        exit
+        ;;
       *)
         # unknown option
         echo "unknown: $key"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,59 @@
 #!/bin/bash
 
+
+# Use -gt 1 to consume two arguments per pass in the loop (e.g. each
+# argument has a corresponding value to go with it).
+# Use -gt 0 to consume one or more arguments per pass in the loop (e.g.
+# some arguments don't have a corresponding value to go with it such
+# as in the --default example).
+# note: if this is set to -gt 0 the /etc/hosts part is not recognized ( may be a bug )
+
+DARWIN_X64="darwin-x64"
+LINUX_X64="linux-x64"
+LINUX_IA32="linux-ia32"
+WIN32_IA32="win32-ia32"
+WIN32_X64="win32-x64"
+
+ALLPLATFORMS=($DARWIN_X64 $LINUX_X64 $LINUX_IA32 $WIN32_IA32 $WIN32_X64)
+PLATFORMS=()
+
+if [[ $# -eq 0 ]]; then
+  PLATFORMS=${ALLPLATFORMS[*]}
+else
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+
+    case $key in
+      --darwin-x64)
+        PLATFORMS=("${PLATFORMS[@]}" $DARWIN_X64)
+        ;;
+      --linux-x64)
+        PLATFORMS=("${PLATFORMS[@]}" $LINUX_X64)
+        ;;
+      --linux-ia32)
+        PLATFORMS=("${PLATFORMS[@]}" $LINUX_IA32)
+        ;;
+      --win32-x64)
+        PLATFORMS=("${PLATFORMS[@]}" $WIN32_X64)
+        ;;
+      --win32-ia32)
+        PLATFORMS=("${PLATFORMS[@]}" $WIN32_IA32)
+        ;;
+      --all)
+        PLATFORMS=${ALLPLATFORMS[*]}
+        break
+        ;;
+      *)
+        # unknown option
+        echo "unknown: $key"
+        exit
+        ;;
+    esac
+    shift # past argument or value
+  done
+fi
+#
 for dep in curl unzip sed; do
   echo "checking dependency... $dep"
   test ! $(which $dep) && echo "ERROR: missing $dep" && exit 1
@@ -7,20 +61,19 @@ done
 
 ELECTRON_VERSION=$(npm list --depth=0 |grep electron-prebuilt | cut -f2 -d@)
 VERSION=$(node -e "console.log(require('./package').version)")
-PLATFORMS=("darwin-x64" "linux-ia32" "linux-x64" "win32-ia32" "win32-x64")
 
 mkdir -p dist
 cd dist
 for PLATFORM in ${PLATFORMS[*]}; do
-    rm -rf $PLATFORM
-    echo "https://github.com/atom/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-$PLATFORM.zip"
-    test ! -f electron-v$ELECTRON_VERSION-$PLATFORM.zip && \
+  rm -rf $PLATFORM
+  echo "https://github.com/atom/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-$PLATFORM.zip"
+  test ! -f electron-v$ELECTRON_VERSION-$PLATFORM.zip && \
     curl -LO https://github.com/atom/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-$PLATFORM.zip
-    unzip -o electron-v$ELECTRON_VERSION-$PLATFORM.zip -d $PLATFORM
+  unzip -o electron-v$ELECTRON_VERSION-$PLATFORM.zip -d $PLATFORM
 done
 
-build_max() {
-  cd darwin-x64
+build_darwin_x64() {
+  cd $DARWIN_X64
   mv Electron.app YakYak.app
   defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleDisplayName -string "YakYak"
   defaults write $(pwd)/YakYak.app/Contents/Info.plist CFBundleExecutable -string "YakYak"
@@ -37,7 +90,7 @@ build_max() {
 }
 
 build_win32_ia32 () {
-  cd win32-ia32
+  cd $WIN32_IA32
   mv electron.exe yakyak.exe
   cp -R ../../app resources/app
   cd ..
@@ -46,7 +99,7 @@ build_win32_ia32 () {
 }
 
 build_win32_x64 () {
-  cd win32-x64
+  cd $WIN32_X64
   mv electron.exe yakyak.exe
   cp -R ../../app resources/app
   cd ..
@@ -55,7 +108,7 @@ build_win32_x64 () {
 }
 
 build_linux_ia32 () {
-  cd linux-ia32
+  cd $LINUX_IA32
   mv electron yakyak
   cp -R ../../app resources/app
   cd ..
@@ -64,7 +117,7 @@ build_linux_ia32 () {
 }
 
 build_linux_x64 () {
-  cd linux-x64
+  cd $LINUX_X64
   mv electron yakyak
   cp -R ../../app resources/app
   cd ..
@@ -73,7 +126,11 @@ build_linux_x64 () {
   cd ..
 }
 
-build_win32_ia32
-build_win32_x64
-build_linux_ia32
-build_linux_x64
+
+[[ $PLATFORMS =~ $DARWIN_X64 ]] && build_darwin_x64
+[[ $PLATFORMS =~ $WIN32_IA32 ]] && build_win32_ia32
+[[ $PLATFORMS =~ $WIN32_X64 ]] && build_win32_x64
+[[ $PLATFORMS =~ $LINUX_IA32 ]] && build_linux_ia32
+[[ $PLATFORMS =~ $LINUX_X64 ]] && build_linux_x64
+
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "gulp": "gulp",
     "electron": "electron",
     "test": "mocha",
-    "deploy": "bash ./deploy.sh"
+    "deploy": "bash ./deploy.sh",
+    "deploy:linux-x64": "bash ./deploy.sh --linux-x64",
+    "deploy:linux-ia32": "bash ./deploy.sh --linux-ia32",
+    "deploy:win32-x64": "bash ./deploy.sh --win32-x64",
+    "deploy:win32-ia32": "bash ./deploy.sh --win32-ia32",
+    "deploy:darwin-x64": "bash ./deploy.sh --darwin-x64"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes to the deploy.sh script, so that it builds to platforms at request (instead of just all)

It keeps current behavior of build all by default.

example to build all:

    $ bash deploy.sh
    $ bash deploy.sh --all

example to build linux-x64 and linux-ia32

    $ bash deploy.sh --linux-x64 --linux-ia32

Also added targets deploy:<platform> to package.json