### PR TITLE
only renders emoji if followed by space or enter

### DIFF
--- a/src/ui/util.coffee
+++ b/src/ui/util.coffee
@@ -82,16 +82,21 @@ convertEmoji = (text) ->
     unicodeMap = require './emojishortcode'
 
     patterns = [
-        ":[a-zA-Z0-9_\+-]+:",
-        ":\\(:\\)|:\\(\\|\\)|:X\\)|:3|\\(=\\^\\.\\.\\^=\\)|\\(=\\^\\.\\^=\\)|=\\^_\\^=|x_x|X-O|X-o|X\\(|X-\\(|O\\.O|:O|:-O|=O|o\\.o|:o|:-o|=o|D:|>_<|T_T|:'\\(|;_;|='\\(|>\\.<|>:\\(|>:-\\(|>=\\(|:\\(|:-\\(|=\\(|;P|;-P|;p|;-p|:P|:-P|=P|:p|:-p|=p|;\\*|;-\\*|:\\*|:-\\*|:S|:-S|:s|:-s|=\\/|=\\\\|:-\\/|:-\\\\|:\\/|:\\\\|u_u|o_o;|-_-|=\\||:\\||:-\\||B-\\)|B\\)|;-\\)|;\\)|}=\\)|}:-\\)|}:\\)|O=\\)|O:-\\)|O:\\)|\\^_\\^;;|=D|\\^_\\^|:-D|:D|~@~|<3|<\\/3|<\\\\3|\\(]:{|-<@%|:\\)|:-\\)|=\\)"
+        "(^|[ ])(:[a-zA-Z0-9_\+-]+:)([ ]$)",
+        "(^|[ ])(:\\(:\\)|:\\(\\|\\)|:X\\)|:3|\\(=\\^\\.\\.\\^=\\)|\\(=\\^\\.\\^=\\)|=\\^_\\^=|x_x|X-O|X-o|X\\(|X-\\(|O\\.O|:O|:-O|=O|o\\.o|:o|:-o|=o|D:|>_<|T_T|:'\\(|;_;|='\\(|>\\.<|>:\\(|>:-\\(|>=\\(|:\\(|:-\\(|=\\(|;P|;-P|;p|;-p|:P|:-P|=P|:p|:-p|=p|;\\*|;-\\*|:\\*|:-\\*|:S|:-S|:s|:-s|=\\/|=\\\\|:-\\/|:-\\\\|:\\/|:\\\\|u_u|o_o;|-_-|=\\||:\\||:-\\||B-\\)|B\\)|;-\\)|;\\)|}=\\)|}:-\\)|}:\\)|O=\\)|O:-\\)|O:\\)|\\^_\\^;;|=D|\\^_\\^|:-D|:D|~@~|<3|<\\/3|<\\\\3|\\(]:{|-<@%|:\\)|:-\\)|=\\))([ ]|$)"
+
     ]
 
     emojiCodeRegex = new RegExp(patterns.join('|'),'g')
 
     text = text.replace(emojiCodeRegex, (emoji) ->
-        unicode = unicodeMap[emoji]
-        return unicode if !!unicode
-        emoji
+        emojiTrim = emoji.trim()
+        trail = if emoji.length > emojiTrim.length
+                    emoji.slice(emojiTrim.length)
+                else
+                    ""
+        unicode = unicodeMap[emojiTrim]
+        return unicode + trail if !!unicode
     )
     return text
 module.exports = {nameof, initialsof, nameofconv, linkto, later, throttle, uniqfn,

--- a/src/ui/util.coffee
+++ b/src/ui/util.coffee
@@ -90,13 +90,10 @@ convertEmoji = (text) ->
     emojiCodeRegex = new RegExp(patterns.join('|'),'g')
 
     text = text.replace(emojiCodeRegex, (emoji) ->
-        emojiTrim = emoji.trim()
-        trail = if emoji.length > emojiTrim.length
-                    emoji.slice(emojiTrim.length)
-                else
-                    ""
-        unicode = unicodeMap[emojiTrim]
-        return unicode + trail if !!unicode
+        suffix = emoji.slice(emoji.trimRight().length)
+        prefix = emoji.slice(0, emoji.length - emoji.trimLeft().length)
+        unicode = unicodeMap[emoji.trim()]
+        return prefix + unicode + suffix if !!unicode
     )
     return text
 module.exports = {nameof, initialsof, nameofconv, linkto, later, throttle, uniqfn,

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -92,6 +92,11 @@ module.exports = view (models) ->
                         action 'hideWindow'
                     if e.keyCode == 13
                         e.preventDefault()
+                        # before sending message, check for emoji
+                        element = document.getElementById "message-input"
+                        # Converts emojicodes (e.g. :smile:, :-) ) to unicode
+                        element.value = convertEmoji(element.value)
+                        #
                         action 'sendmessage', e.target.value
                         document.querySelector('#emoji-container').classList.remove('open');
                         historyPush e.target.value


### PR DESCRIPTION
Better replicates Google Hangouts emoji conversion by:
- Only converting emojis that a whole word
- Converts last written word to emoji if press enter

Test cases (spaces or enter are denoted as ``«space|enter»``)
 "I«space»like«space»it!«space»:)«enter»"  -> correct emoji
":D«enter»"  -> correct emoji
"-_-«space»«enter»" -> correct emoji
"The«space»url«space»is«space»http://github.com«space»«enter»" -> "The url is http://github.com"
"The«space»url«space»is«space»http://github.com«enter»" -> "The url is http://github.com"

![selection_022](https://cloud.githubusercontent.com/assets/211358/17111806/1505732e-529b-11e6-8d4a-b4039f41495d.png)
