### PR TITLE
corrects cursor position when hitting space (if it has emoji short code in the msg)

### DIFF
--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -110,8 +110,14 @@ module.exports = view (models) ->
                 #check for emojis after pressing space
                 if e.keyCode == 32
                     element = document.getElementById "message-input"
+                    # get cursor position
+                    startSel = element.selectionStart
+                    endSel  = element.selectionEnd
                     # Converts emojicodes (e.g. :smile:, :-) ) to unicode
                     element.value = convertEmoji(element.value)
+                    # Set cursor position (otherwise it would go to end of inpu)
+                    element.selectionStart = startSel
+                    element.selectionEnd = endSel
             , onpaste: (e) ->
                 setTimeout () ->
                     if not clipboard.readImage().isEmpty() and not clipboard.readText()


### PR DESCRIPTION
This fixes the cursor position to stay as it was before hitting space.

This is relevant when there is an emoji on the message (eg. ``:)``):

- editing something in the middle of the message and pressing space would move the cursor to the end of the message
