### PR TITLE
Opening links in conversation without google.com/url?q= redirects

### DIFF
--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -28,9 +28,11 @@ fixProxied = (e, proxied, entity) ->
 onclick = (e) ->
   e.preventDefault()
   address = e.currentTarget.getAttribute 'href'
-  pre = 'https://www.google.com/url?q='
-  address = address.slice(pre.length)
-  address = unescape(address)
+  alert address
+  patt = new RegExp("^http(s)?[:][/][/]www[.]google[.](com|[a-z][a-z])[/]url[?]q[=]")
+  if patt.test(address)
+    address = address.replace(patt, '')
+    address = unescape(address)
   shell.openExternal fixlink(address)
 
 # helper method to group events in time/user bunches

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -28,6 +28,9 @@ fixProxied = (e, proxied, entity) ->
 onclick = (e) ->
   e.preventDefault()
   address = e.currentTarget.getAttribute 'href'
+  pre = 'https://www.google.com/url?q='
+  address = address.slice(pre.length)
+  address = unescape(address)
   shell.openExternal fixlink(address)
 
 # helper method to group events in time/user bunches

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -28,10 +28,9 @@ fixProxied = (e, proxied, entity) ->
 onclick = (e) ->
   e.preventDefault()
   address = e.currentTarget.getAttribute 'href'
-  alert address
-  patt = new RegExp("^http(s)?[:][/][/]www[.]google[.](com|[a-z][a-z])[/]url[?]q[=]")
+  patt = new RegExp("^(https?[:][/][/]www[.]google[.](com|[a-z][a-z])[/]url[?]q[=])([^&]+)(&.+)*")
   if patt.test(address)
-    address = address.replace(patt, '')
+    address = address.replace(patt, '$3')
     address = unescape(address)
   shell.openExternal fixlink(address)
 


### PR DESCRIPTION
I really don't like the fact that links from yakyak go through Google before actually opening the links.

I've been testing this for a while and to this date I have not found a single unworkable link with the present code.

So I present two questions:
- *Is this interesting for anyone else?*
- Does this redirect also protects users from malicious sites, or is it just looking at which sites are visited?

note for merging: if in fact this seems interesting by devs/users I guess there should be an option that defaults to disable this, and maintain current functionality.

ps. This is what actually got me started on developing for yakyak :)