### PR TITLE
#331 Option in me enabling/disabling converting to emojis in messages

### DIFF
--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -359,6 +359,9 @@ handle 'showconvtime', (doshow) ->
 handle 'showconvlast', (doshow) ->
     viewstate.setShowConvLast doshow
 
+handle 'convertemoji', (doshow) ->
+    viewstate.setConvertEmoji doshow
+
 handle 'changetheme', (colorscheme) ->
     viewstate.setColorScheme colorscheme
 

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -22,6 +22,7 @@ module.exports = exp = {
     showAnimatedThumbs: tryparse(localStorage.showAnimatedThumbs) ? true
     showConvTime: tryparse(localStorage.showConvTime) ? true
     showConvLast: tryparse(localStorage.showConvLast) ? true
+    convertEmoji: tryparse(localStorage.convertEmoji) ? true
     colorScheme: localStorage.colorScheme or 'default'
     fontSize: localStorage.fontSize or 'medium'
     zoom: tryparse(localStorage.zoom ? "1.0")
@@ -154,6 +155,11 @@ module.exports = exp = {
     setShowConvLast: (doshow) ->
         return if @showConvLast == doshow
         @showConvLast = localStorage.showConvLast = doshow
+        updated 'viewstate'
+
+    setConvertEmoji: (doshow) ->
+        return if @convertEmoji == doshow
+        @convertEmoji = localStorage.convertEmoji = doshow
         updated 'viewstate'
 
     setColorScheme: (colorscheme) ->

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -92,10 +92,11 @@ module.exports = view (models) ->
                         action 'hideWindow'
                     if e.keyCode == 13
                         e.preventDefault()
-                        # before sending message, check for emoji
-                        element = document.getElementById "message-input"
-                        # Converts emojicodes (e.g. :smile:, :-) ) to unicode
-                        element.value = convertEmoji(element.value)
+                        if models.viewstate.convertEmoji
+                            # before sending message, check for emoji
+                            element = document.getElementById "message-input"
+                            # Converts emojicodes (e.g. :smile:, :-) ) to unicode
+                            element.value = convertEmoji(element.value)
                         #
                         action 'sendmessage', e.target.value
                         document.querySelector('#emoji-container').classList.remove('open');
@@ -114,7 +115,8 @@ module.exports = view (models) ->
                     startSel = element.selectionStart
                     endSel  = element.selectionEnd
                     # Converts emojicodes (e.g. :smile:, :-) ) to unicode
-                    element.value = convertEmoji(element.value)
+                    if models.viewstate.convertEmoji
+                        element.value = convertEmoji(element.value)
                     # Set cursor position (otherwise it would go to end of inpu)
                     element.selectionStart = startSel
                     element.selectionEnd = endSel

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -60,7 +60,7 @@ templateOsx = (viewstate) -> [{
         }, {
             type: 'checkbox'
             label: 'Convert text to emoji'
-            checked:viewstate.convertEmoji
+            checked: viewstate.convertEmoji
             enabled: viewstate.loggedin
             click: (it) -> action 'convertemoji', it.checked
         },
@@ -290,6 +290,12 @@ templateOthers = (viewstate) -> [{
             checked:viewstate.showConvLast
             enabled: viewstate.loggedin
             click: (it) -> action 'showconvlast', it.checked
+        }, {
+            type: 'checkbox'
+            label: 'Convert text to emoji'
+            checked: viewstate.convertEmoji
+            enabled: viewstate.loggedin
+            click: (it) -> action 'convertemoji', it.checked
         }, {
             label: 'Color Scheme'
             submenu: [

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -315,12 +315,6 @@ templateOthers = (viewstate) -> [{
                     click: -> action 'changetheme', 'material'
                 }
             ]
-        }, {
-            type: 'checkbox'
-            label: 'Convert to emoji as you type'
-            checked:viewstate.convertEmoji
-            enabled: viewstate.loggedin
-            click: (it) -> action 'convertemoji', it.checked
         },
          {
             label: 'Font Size'

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -59,7 +59,7 @@ templateOsx = (viewstate) -> [{
             click: (it) -> action 'showconvlast', it.checked
         }, {
             type: 'checkbox'
-            label: 'Convert to emoji as you type'
+            label: 'Convert text to emoji'
             checked:viewstate.convertEmoji
             enabled: viewstate.loggedin
             click: (it) -> action 'convertemoji', it.checked

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -58,6 +58,13 @@ templateOsx = (viewstate) -> [{
             enabled: viewstate.loggedin
             click: (it) -> action 'showconvlast', it.checked
         }, {
+            type: 'checkbox'
+            label: 'Convert to emoji as you type'
+            checked:viewstate.convertEmoji
+            enabled: viewstate.loggedin
+            click: (it) -> action 'convertemoji', it.checked
+        },
+         {
             label: 'Color Scheme'
             submenu: [
                 {
@@ -309,6 +316,13 @@ templateOthers = (viewstate) -> [{
                 }
             ]
         }, {
+            type: 'checkbox'
+            label: 'Convert to emoji as you type'
+            checked:viewstate.convertEmoji
+            enabled: viewstate.loggedin
+            click: (it) -> action 'convertemoji', it.checked
+        },
+         {
             label: 'Font Size'
             submenu: [
                 {


### PR DESCRIPTION
#331 Option to enable/disable convert to text to emoji

![image](https://cloud.githubusercontent.com/assets/211358/18100724/f816154c-6ee3-11e6-8ba6-a32acfa8e353.png)

*Possible conflict* with #319 which is a much cleaner implementation on sending messsages.

### What does it do:

When disabled ':)' and other emojis are not converted to unicode and are just sent as plain text.

### What it does not do:

Convert incoming or past messages from emojis to text.

### Example:

- Message one - enabled
- Message two - disabled

![image](https://cloud.githubusercontent.com/assets/211358/18100804/42a65824-6ee4-11e6-87ed-40f368e7311d.png)

Is there a convention on option titles? (almost all are all capitalized, except "show system tray"
