### PR TITLE
make it work better with big convos

### DIFF
--- a/src/ui/css/yakyak/convhead.less
+++ b/src/ui/css/yakyak/convhead.less
@@ -18,6 +18,7 @@
 		font-size: ~"calc(16px / var(--zoom))";
 		font-weight: bold;
 		text-align: center;
+		overflow: hidden;
 		.material-icons{
 			font-size: .82em;
 			margin-right: 2px;

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -79,6 +79,8 @@ module.exports = view (models) ->
 
     conv_id = viewstate?.selectedConv
     c = conv[conv_id]
+    for participant in c.current_participant
+      entity.needEntity participant.chat_id
     div class:'messages', observe:onMutate(viewstate), ->
         return unless c?.event
         grouped = groupEvents c.event, entity


### PR DESCRIPTION
in the case of a big conversation there were 2 issues:

1. profile entities weren't being fetched for > 4 (ish?) people in the
  convo
2. if the title was long, it overflowed into the conversation view

i tried to fix #2 with an ellipsis, but that was card cause i don't kno
flexbox, so instead i just hid the long title ¯\_(ツ)_/¯