### PR TITLE
Simplify menu template by removing duplicate entries

### DIFF
--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -34,16 +34,16 @@ acceleratorMap = {
 }
 
 templateYakYak = (viewstate) ->
-    tmp = []
+    tmpl = []
     if os.platform() == 'darwin'
-        tmp = tmp.concat [
+        tmpl.push [
             { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' }
             #{ type: 'separator' }
             # { label: 'Preferences...', accelerator: 'Command+,',
             # click: => delegate.openConfig() }
             { type: 'separator' }
         ]
-    tmp = tmp.concat [
+    tmpl.push [
         {
             label: 'Hide YakYak'
             accelerator: acceleratorMap['hideyakyak'][os]
@@ -52,14 +52,14 @@ templateYakYak = (viewstate) ->
     ]
 
     if os.platform() == 'darwin'
-        tmp = tmp.concat [{
+        tmpl.push [{
               label: 'Hide Others'
               accelerator: acceleratorMap['hideother'][os]
               selector: 'hideOtherApplications:'
         }
         { label: 'Show All', selector: 'unhideAllApplications:' }
         ]
-    tmp.concat [
+    tmpl.push [
       { type: 'separator' }
       {
           label: 'Open Inspector'
@@ -80,22 +80,22 @@ templateYakYak = (viewstate) ->
   ]
 
 templateEdit = (viewstate) ->
-    tmp = [
+    tmpl = [
         { label: 'Undo', accelerator: acceleratorMap['undo'][os], selector: 'undo:' }
         { label: 'Redo', accelerator: acceleratorMap['redo'][os], selector: 'redo:' }
     ]
     if os.platform() == 'darwin'
-        tmp = tmp.concat [
+        tmpl.push [
           { type: 'separator' }
           { label: 'Cut', accelerator: acceleratorMap['cut'][os], selector: 'cut:' }
           { label: 'Copy', accelerator: acceleratorMap['copy'][os], selector: 'copy:' }
           { label: 'Paste', accelerator: acceleratorMap['paste'][os], selector: 'paste:' }
           { label: 'Select All', accelerator: acceleratorMap['selectall'][os], selector: 'selectAll:' }
         ]
-    tmp
+    tmpl
 
 templateView = (viewstate) ->
-    tmp = [
+    tmpl = [
         {
             label: 'Conversation List'
             submenu: [
@@ -280,17 +280,17 @@ templateView = (viewstate) ->
         }
     ]
     if os.platform() == 'darwin'
-        tmp = tmp.concat {
+        tmpl.push {
             label: 'Hide Dock icon'
             type: 'checkbox'
             enabled: viewstate.showtray
             checked:  viewstate.hidedockicon
             click: -> action 'togglehidedockicon'
         }
-    tmp
+    tmpl
 
 templateWindow = (viewstate, os) ->
-    tmp = [
+    tmpl = [
         {
             label: 'Minimize'
             accelerator: acceleratorMap['minimize'][os]
@@ -307,37 +307,24 @@ templateWindow = (viewstate, os) ->
         }
     ]
 
-templateOsx = (viewstate) -> [
-    {
-        label: 'YakYak'
-        submenu: templateYakYak viewstate
-    }, {
-        label: 'Edit'
-        submenu: templateEdit viewstate
-    },{
-        label: 'View'
-        submenu: templateView viewstate
-    }, {
-        label: 'Window'
-        submenu: templateWindow viewstate
-    }
-  ]
-
-templateOthers = (viewstate) -> [
-    {
-        label: 'YakYak'
-        submenu: templateYakYak viewstate
-    }, {
-        label: 'Edit'
-        submenu: templateEdit viewstate
-    },{
-        label: 'View'
-        submenu: templateView viewstate
-    }
-  ]
+templateMenu = (viewstate) ->
+    tmpl = [{
+            label: 'YakYak'
+            submenu: templateYakYak viewstate
+        }, {
+            label: 'Edit'
+            submenu: templateEdit viewstate
+        },{
+            label: 'View'
+            submenu: templateView viewstate
+        }
+    ]
+    if os.platform() == 'darwin'
+        tmpl.push {
+            label: 'Window'
+            submenu: templateWindow viewstate
+        }
+    tmpl
 
 module.exports = (viewstate) ->
-    if os.platform() == 'darwin'
-        Menu.setApplicationMenu Menu.buildFromTemplate templateOsx(viewstate)
-    else
-        Menu.setApplicationMenu Menu.buildFromTemplate templateOthers(viewstate)
+    Menu.setApplicationMenu Menu.buildFromTemplate templateMenu(viewstate)

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -1,5 +1,4 @@
 remote = require('electron').remote
-os = require('os')
 Menu = remote.Menu
 
 acceleratorMap = {
@@ -33,9 +32,9 @@ acceleratorMap = {
     close:                {others: '', osx: 'Command+W'}
 }
 
-templateYakYak = (viewstate) ->
+templateYakYak = (viewstate, os) ->
     tmpl = []
-    if os.platform() == 'darwin'
+    if os == 'darwin'
         tmpl.push [
             { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' }
             #{ type: 'separator' }
@@ -51,7 +50,7 @@ templateYakYak = (viewstate) ->
         }
     ]
 
-    if os.platform() == 'darwin'
+    if os == 'darwin'
         tmpl.push [{
               label: 'Hide Others'
               accelerator: acceleratorMap['hideother'][os]
@@ -79,12 +78,12 @@ templateYakYak = (viewstate) ->
       }
   ]
 
-templateEdit = (viewstate) ->
+templateEdit = (viewstate, os) ->
     tmpl = [
         { label: 'Undo', accelerator: acceleratorMap['undo'][os], selector: 'undo:' }
         { label: 'Redo', accelerator: acceleratorMap['redo'][os], selector: 'redo:' }
     ]
-    if os.platform() == 'darwin'
+    if os == 'darwin'
         tmpl.push [
           { type: 'separator' }
           { label: 'Cut', accelerator: acceleratorMap['cut'][os], selector: 'cut:' }
@@ -94,7 +93,7 @@ templateEdit = (viewstate) ->
         ]
     tmpl
 
-templateView = (viewstate) ->
+templateView = (viewstate, os) ->
     tmpl = [
         {
             label: 'Conversation List'
@@ -279,7 +278,7 @@ templateView = (viewstate) ->
             click: -> action 'toggleshowtray'
         }
     ]
-    if os.platform() == 'darwin'
+    if os == 'darwin'
         tmpl.push {
             label: 'Hide Dock icon'
             type: 'checkbox'
@@ -289,7 +288,7 @@ templateView = (viewstate) ->
         }
     tmpl
 
-templateWindow = (viewstate) -> [
+templateWindow = (viewstate, os) -> [
     {
         label: 'Minimize'
         accelerator: acceleratorMap['minimize'][os]
@@ -307,21 +306,22 @@ templateWindow = (viewstate) -> [
 ]
 
 templateMenu = (viewstate) ->
+    os = if require('os').platform() == 'darwin' then 'darwin' else 'others'
     tmpl = [{
             label: 'YakYak'
-            submenu: templateYakYak viewstate
+            submenu: templateYakYak viewstate, os
         }, {
             label: 'Edit'
-            submenu: templateEdit viewstate
+            submenu: templateEdit viewstate, os
         },{
             label: 'View'
-            submenu: templateView viewstate
+            submenu: templateView viewstate, os
         }
     ]
-    if os.platform() == 'darwin'
+    if os == 'darwin'
         tmpl.push {
             label: 'Window'
-            submenu: templateWindow viewstate
+            submenu: templateWindow viewstate, os
         }
     tmpl
 

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -1,74 +1,136 @@
 remote = require('electron').remote
+os = require('os')
 Menu = remote.Menu
 
-templateOsx = (viewstate) -> [{
-    label: 'YakYak'
-    submenu: [
-        { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' }
-        { type: 'separator' }
-        # { label: 'Preferences...', accelerator: 'Command+,', click: => delegate.openConfig() }
-        { type: 'separator' }
-        { label: 'Hide YakYak', accelerator: 'Command+H', selector: 'hide:' }
-        { label: 'Hide Others', accelerator: 'Command+Shift+H', selector: 'hideOtherApplications:' }
-        { label: 'Show All', selector: 'unhideAllApplications:' }
-        { type: 'separator' }
-        { label: 'Open Inspector', accelerator: 'Command+Alt+I', click: -> action 'devtools' }
-        { type: 'separator' }
+acceleratorMap = {
+    hideyakyak:           {others: 'Control+H', osx: 'Command+H'}
+    hideothers:           {others: '', osx: 'Command+Shift+H'}
+    showall:              {others: '', osx: ''}
+    openinspector:        {others: 'Control+Alt+I', osx: 'Command+Alt+I'}
+    quit:                 {others: 'Control+Q', osx: 'Command+Q'}
+    undo:                 {others: 'Control+Z', osx: 'Command+Z'}
+    redo:                 {others: 'Control+Shift+Z', osx: 'Command+Shift+Z'}
+    cut:                  {others: '', osx: 'Command+X'}
+    copy:                 {others: '', osx: 'Command+C'}
+    paste:                {others: '', osx: 'Command+V'}
+    selectall:            {others: '', osx: 'Command+A'}
+    togglefullscreen:     {others: 'Control+Alt+F', osx: 'Command+Control+F'}
+    zoomin:               {others: 'Control+Plus', osx: 'Command+Plus'}
+    zoomout:              {others: 'Control+-', osx: 'Command+-'}
+    resetzoom:            {others: 'Control+0', osx: 'Command+0'}
+    previousconversation: {others: 'Control+K', osx: 'Command+Shift+Tab'}
+    nextconversation:     {others: 'Control+J', osx: 'Command+Tab'}
+    conversation1:        {others: 'Alt+1', osx: 'Command+1'}
+    conversation2:        {others: 'Alt+2', osx: 'Command+2'}
+    conversation3:        {others: 'Alt+3', osx: 'Command+3'}
+    conversation4:        {others: 'Alt+4', osx: 'Command+4'}
+    conversation5:        {others: 'Alt+5', osx: 'Command+5'}
+    conversation6:        {others: 'Alt+6', osx: 'Command+6'}
+    conversation7:        {others: 'Alt+7', osx: 'Command+7'}
+    conversation8:        {others: 'Alt+8', osx: 'Command+8'}
+    conversation9:        {others: 'Alt+9', osx: 'Command+9'}
+    minimize:             {others: '', osx: 'Command+M'}
+    close:                {others: '', osx: 'Command+W'}
+}
+
+templateYakYak = (viewstate) ->
+    tmp = []
+    if os.platform() == 'darwin'
+        tmp = tmp.concat [
+            { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' }
+            #{ type: 'separator' }
+            # { label: 'Preferences...', accelerator: 'Command+,',
+            # click: => delegate.openConfig() }
+            { type: 'separator' }
+        ]
+    tmp = tmp.concat [
         {
+            label: 'Hide YakYak'
+            accelerator: acceleratorMap['hideyakyak'][os]
+            selector: 'hide:'
+        }
+    ]
+
+    if os.platform() == 'darwin'
+        tmp = tmp.concat [{
+              label: 'Hide Others'
+              accelerator: acceleratorMap['hideother'][os]
+              selector: 'hideOtherApplications:'
+        }
+        { label: 'Show All', selector: 'unhideAllApplications:' }
+        ]
+    tmp.concat [
+      { type: 'separator' }
+      {
+          label: 'Open Inspector'
+          accelerator: acceleratorMap['openinspector'][os]
+          click: -> action 'devtools'
+      }
+      { type: 'separator' }
+      {
           label: 'Logout',
           click: -> action 'logout'
           enabled: viewstate.loggedin
-        }
-        { label: 'Quit', accelerator: 'Command+Q', click: -> action 'quit' }
-    ]},{
-    label: 'Edit'
-    submenu: [
-        { label: 'Undo', accelerator: 'Command+Z', selector: 'undo:' }
-        { label: 'Redo', accelerator: 'Command+Shift+Z', selector: 'redo:' }
-        { type: 'separator' }
-        { label: 'Cut', accelerator: 'Command+X', selector: 'cut:' }
-        { label: 'Copy', accelerator: 'Command+C', selector: 'copy:' }
-        { label: 'Paste', accelerator: 'Command+V', selector: 'paste:' }
-        { label: 'Select All', accelerator: 'Command+A', selector: 'selectAll:' }
-    ]},{
-    label: 'View'
-    submenu: [
+      }
+      {
+          label: 'Quit'
+          accelerator: acceleratorMap['quit'][os]
+          click: -> action 'quit'
+      }
+  ]
+
+templateEdit = (viewstate) ->
+    tmp = [
+        { label: 'Undo', accelerator: acceleratorMap['undo'][os], selector: 'undo:' }
+        { label: 'Redo', accelerator: acceleratorMap['redo'][os], selector: 'redo:' }
+    ]
+    if os.platform() == 'darwin'
+        tmp = tmp.concat [
+          { type: 'separator' }
+          { label: 'Cut', accelerator: acceleratorMap['cut'][os], selector: 'cut:' }
+          { label: 'Copy', accelerator: acceleratorMap['copy'][os], selector: 'copy:' }
+          { label: 'Paste', accelerator: acceleratorMap['paste'][os], selector: 'paste:' }
+          { label: 'Select All', accelerator: acceleratorMap['selectall'][os], selector: 'selectAll:' }
+        ]
+    tmp
+
+templateView = (viewstate) ->
+    tmp = [
         {
             label: 'Conversation List'
             submenu: [
-                {
-                    type: 'checkbox'
-                    label: 'Show Thumbnails'
-                    checked:viewstate.showConvThumbs
-                    enabled: viewstate.loggedin
-                    click: (it) -> action 'showconvthumbs', it.checked
-                }, {
-                    type: 'checkbox'
-                    label: 'Show Thumbnails Only'
-                    checked:viewstate.showConvMin
-                    enabled: viewstate.loggedin
-                    click: (it) -> action 'showconvmin', it.checked
-                }, {
-                    type: 'checkbox'
-                    label: 'Show Animated Thumbnails'
-                    checked:viewstate.showAnimatedThumbs
-                    enabled: viewstate.loggedin
-                    click: (it) -> action 'showanimatedthumbs', it.checked
-                }, {
-                    type: 'checkbox'
-                    label: 'Show Conversation Timestamp'
-                    checked:viewstate.showConvTime
-                    enabled: viewstate.loggedin && !viewstate.showConvMin
-                    click: (it) -> action 'showconvtime', it.checked
-                }, {
-                    type: 'checkbox'
-                    label: 'Show Conversation Last Message'
-                    checked:viewstate.showConvLast
-                    enabled: viewstate.loggedin && !viewstate.showConvMin
-                    click: (it) -> action 'showconvlast', it.checked
-                }
-            ]
-
+              {
+                  type: 'checkbox'
+                  label: 'Show Thumbnails'
+                  checked: viewstate.showConvThumbs
+                  enabled: viewstate.loggedin
+                  click: (it) -> action 'showconvthumbs', it.checked
+              }, {
+                  type: 'checkbox'
+                  label: 'Show Thumbnails Only'
+                  checked:viewstate.showConvMin
+                  enabled: viewstate.loggedin
+                  click: (it) -> action 'showconvmin', it.checked
+              }, {
+                  type: 'checkbox'
+                  label: 'Show Animated Thumbnails'
+                  checked:viewstate.showAnimatedThumbs
+                  enabled: viewstate.loggedin
+                  click: (it) -> action 'showanimatedthumbs', it.checked
+              }, {
+                  type: 'checkbox'
+                  label: 'Show Conversation Timestamp'
+                  checked:viewstate.showConvTime
+                  enabled: viewstate.loggedin && !viewstate.showConvMin
+                  click: (it) -> action 'showconvtime', it.checked
+              }, {
+                  type: 'checkbox'
+                  label: 'Show Conversation Last Message'
+                  checked:viewstate.showConvLast
+                  enabled: viewstate.loggedin && !viewstate.showConvMin
+                  click: (it) -> action 'showconvlast', it.checked
+              }
+          ]
         }, {
             type: 'checkbox'
             label: 'Show Pop-Up (Toast) Notifications'
@@ -81,90 +143,88 @@ templateOsx = (viewstate) -> [{
             checked: viewstate.convertEmoji
             enabled: viewstate.loggedin
             click: (it) -> action 'convertemoji', it.checked
-        },
-         {
+        }, {
             label: 'Color Scheme'
             submenu: [
-                {
-                    label: 'Default'
-                    type: 'radio'
-                    checked: viewstate.colorScheme == 'default'
-                    click: -> action 'changetheme', 'default'
-                }, {
-                    label: 'Blue'
-                    type: 'radio'
-                    checked: viewstate.colorScheme == 'blue'
-                    click: -> action 'changetheme', 'blue'
-                }, {
-                    label: 'Dark'
-                    type: 'radio'
-                    checked: viewstate.colorScheme == 'dark'
-                    click: -> action 'changetheme', 'dark'
-                }, {
-                    label: 'Material'
-                    type: 'radio'
-                    checked: viewstate.colorScheme == 'material'
-                    click: -> action 'changetheme', 'material'
-                }
+              {
+                  label: 'Default'
+                  type: 'radio'
+                  checked: viewstate.colorScheme == 'default'
+                  click: -> action 'changetheme', 'default'
+              }, {
+                  label: 'Blue'
+                  type: 'radio'
+                  checked: viewstate.colorScheme == 'blue'
+                  click: -> action 'changetheme', 'blue'
+              }, {
+                  label: 'Dark'
+                  type: 'radio'
+                  checked: viewstate.colorScheme == 'dark'
+                  click: -> action 'changetheme', 'dark'
+              }, {
+                  label: 'Material'
+                  type: 'radio'
+                  checked: viewstate.colorScheme == 'material'
+                  click: -> action 'changetheme', 'material'
+              }
             ]
         }, {
             label: 'Font Size'
             submenu: [
-                {
-                    label: 'Extra Small'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'x-small'
-                    click: -> action 'changefontsize', 'x-small'
-                }, {
-                    label: 'Small'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'small'
-                    click: -> action 'changefontsize', 'small'
-                }, {
-                    label: 'Medium'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'medium'
-                    click: -> action 'changefontsize', 'medium'
-                }, {
-                    label: 'Large'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'large'
-                    click: -> action 'changefontsize', 'large'
-                }, {
-                    label: 'Extra Large'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'x-large'
-                    click: -> action 'changefontsize', 'x-large'
-                }
+              {
+                  label: 'Extra Small'
+                  type: 'radio'
+                  checked: viewstate.fontSize == 'x-small'
+                  click: -> action 'changefontsize', 'x-small'
+              }, {
+                  label: 'Small'
+                  type: 'radio'
+                  checked: viewstate.fontSize == 'small'
+                  click: -> action 'changefontsize', 'small'
+              }, {
+                  label: 'Medium'
+                  type: 'radio'
+                  checked: viewstate.fontSize == 'medium'
+                  click: -> action 'changefontsize', 'medium'
+              }, {
+                  label: 'Large'
+                  type: 'radio'
+                  checked: viewstate.fontSize == 'large'
+                  click: -> action 'changefontsize', 'large'
+              }, {
+                  label: 'Extra Large'
+                  type: 'radio'
+                  checked: viewstate.fontSize == 'x-large'
+                  click: -> action 'changefontsize', 'x-large'
+              }
             ]
-
         }, {
             label: 'Toggle Full Screen',
-            accelerator: 'Command+Control+F',
+            accelerator: acceleratorMap['togglefullscreen'][os],
             click: -> action 'togglefullscreen'
         }, {
             # seee https://github.com/atom/electron/issues/1507
             label: 'Zoom In',
-            accelerator: 'Command+Plus',
+            accelerator: acceleratorMap['zoomin'][os],
             click: -> action 'zoom', +0.25
         }, {
             label: 'Zoom Out',
-            accelerator: 'Command+-',
+            accelerator: acceleratorMap['zoomout'][os],
             click: -> action 'zoom', -0.25
         }, {
             label: 'Reset Zoom',
-            accelerator: 'Command+0',
+            accelerator: acceleratorMap['resetzoom'][os],
             click: -> action 'zoom'
         }, {
             type: 'separator'
         }, {
             label: 'Previous Conversation',
-            accelerator: 'Control+Shift+Tab'
+            accelerator: acceleratorMap['previousconversation'][os]
             enabled: viewstate.loggedin
             click: -> action 'selectNextConv', -1
         }, {
             label: 'Next Conversation',
-            accelerator: 'Control+Tab'
+            accelerator: acceleratorMap['nextconversation'][os]
             enabled: viewstate.loggedin
             click: -> action 'selectNextConv', +1
         }, {
@@ -172,49 +232,41 @@ templateOsx = (viewstate) -> [{
             enabled: viewstate.loggedin
             submenu: [
               {
-                label: 'Conversation 1'
-                accelerator: 'Command+1'
-                click: -> action 'selectConvIndex', 0
-              },
-              {
-                label: 'Conversation 2'
-                accelerator: 'Command+2'
-                click: -> action 'selectConvIndex', 1
-              },
-              {
-                label: 'Conversation 3'
-                accelerator: 'Command+3'
-                click: -> action 'selectConvIndex', 2
-              },
-              {
-                label: 'Conversation 4'
-                accelerator: 'Command+4'
-                click: -> action 'selectConvIndex', 3
-              },
-              {
-                label: 'Conversation 5'
-                accelerator: 'Command+5'
-                click: -> action 'selectConvIndex', 4
-              },
-              {
-                label: 'Conversation 6'
-                accelerator: 'Command+6'
-                click: -> action 'selectConvIndex', 5
-              },
-              {
-                label: 'Conversation 7'
-                accelerator: 'Command+7'
-                click: -> action 'selectConvIndex', 6
-              },
-              {
-                label: 'Conversation 8'
-                accelerator: 'Command+8'
-                click: -> action 'selectConvIndex', 7
-              },
-              {
-                label: 'Conversation 9'
-                accelerator: 'Command+9'
-                click: -> action 'selectConvIndex', 8
+                  label: 'Conversation 1'
+                  accelerator: acceleratorMap['conversation1'][os]
+                  click: -> action 'selectConvIndex', 0
+              }, {
+                  label: 'Conversation 2'
+                  accelerator: acceleratorMap['conversation2'][os]
+                  click: -> action 'selectConvIndex', 1
+              }, {
+                  label: 'Conversation 3'
+                  accelerator: acceleratorMap['conversation3'][os]
+                  click: -> action 'selectConvIndex', 2
+              }, {
+                  label: 'Conversation 4'
+                  accelerator: acceleratorMap['conversation4'][os]
+                  click: -> action 'selectConvIndex', 3
+              }, {
+                  label: 'Conversation 5'
+                  accelerator: acceleratorMap['conversation5'][os]
+                  click: -> action 'selectConvIndex', 4
+              }, {
+                  label: 'Conversation 6'
+                  accelerator: acceleratorMap['conversation6'][os]
+                  click: -> action 'selectConvIndex', 5
+              }, {
+                  label: 'Conversation 7'
+                  accelerator: acceleratorMap['conversation7'][os]
+                  click: -> action 'selectConvIndex', 6
+              }, {
+                  label: 'Conversation 8'
+                  accelerator: acceleratorMap['conversation8'][os]
+                  click: -> action 'selectConvIndex', 7
+              }, {
+                  label: 'Conversation 9'
+                  accelerator: acceleratorMap['conversation9'][os]
+                  click: -> action 'selectConvIndex', 8
               }
             ]
         }, {
@@ -225,262 +277,67 @@ templateOsx = (viewstate) -> [{
             enabled: not viewstate.hidedockicon
             checked:  viewstate.showtray
             click: -> action 'toggleshowtray'
-        }, {
+        }
+    ]
+    if os.platform() == 'darwin'
+        tmp = tmp.concat {
             label: 'Hide Dock icon'
             type: 'checkbox'
             enabled: viewstate.showtray
             checked:  viewstate.hidedockicon
             click: -> action 'togglehidedockicon'
         }
-    ]}, {
-    label: 'Window',
-    submenu: [
+    tmp
+
+templateWindow = (viewstate, os) ->
+    tmp = [
         {
-            label: 'Minimize',
-            accelerator: 'Command+M',
+            label: 'Minimize'
+            accelerator: acceleratorMap['minimize'][os]
             selector: 'performMiniaturize:'
-        },
-        {
-            label: 'Close',
-            accelerator: 'Command+W',
+        }, {
+            label: 'Close'
+            accelerator: acceleratorMap['close'][os]
             selector: 'performClose:'
-        },
-        {
+        }, {
             type: 'separator'
-        },
-        {
+        }, {
             label: 'Bring All to Front',
             selector: 'arrangeInFront:'
         }
-      ]
+    ]
+
+templateOsx = (viewstate) -> [
+    {
+        label: 'YakYak'
+        submenu: templateYakYak viewstate
+    }, {
+        label: 'Edit'
+        submenu: templateEdit viewstate
+    },{
+        label: 'View'
+        submenu: templateView viewstate
+    }, {
+        label: 'Window'
+        submenu: templateWindow viewstate
     }
-]
+  ]
 
-# TODO: find proper windows/linux accelerators
-templateOthers = (viewstate) -> [{
-    label: 'YakYak'
-    submenu: [
-        { label: 'Hide YakYak', accelerator: 'Control+H', role: 'minimize' }
-        { type: 'separator' }
-        { label: 'Open Inspector', accelerator: 'Control+Alt+I', click: -> action 'devtools' }
-        { type: 'separator' }
-        { type: 'separator' }
-        {
-          label: 'Logout',
-          click: -> action 'logout'
-          enabled: viewstate.loggedin
-        }
-        { label: 'Quit', accelerator: 'Control+Q', click: -> action 'quit' }
-    ]}, {
-    label: 'Edit'
-    submenu: [
-        { label: 'Undo', accelerator: 'Control+Z', role: 'undo' }
-        { label: 'Redo', accelerator: 'Control+Shift+Z', role: 'redo' }
-       # { type: 'separator' }
-       # { label: 'Cut', accelerator: 'Control+X', role: 'cut' }
-       # { label: 'Copy', accelerator: 'Control+C', role: 'copy' }
-       # { label: 'Paste', accelerator: 'Control+V', role: 'paste' }
-       # { label: 'Select All', accelerator: 'Control+A', role: 'selectall' }
-    ]}, {
-    label: 'View'
-    submenu: [
-        {
-            label: 'Conversation List'
-            submenu: [
-                {
-                    type: 'checkbox'
-                    label: 'Show Thumbnails'
-                    checked:viewstate.showConvThumbs
-                    enabled: viewstate.loggedin
-                    click: (it) -> action 'showconvthumbs', it.checked
-                }, {
-                    type: 'checkbox'
-                    label: 'Show Thumbnails Only'
-                    checked:viewstate.showConvMin
-                    enabled: viewstate.loggedin
-                    click: (it) -> action 'showconvmin', it.checked
-                }, {
-                    type: 'checkbox'
-                    label: 'Show Animated Thumbnails'
-                    checked:viewstate.showAnimatedThumbs
-                    enabled: viewstate.loggedin
-                    click: (it) -> action 'showanimatedthumbs', it.checked
-                }, {
-                    type: 'checkbox'
-                    label: 'Show Conversation Timestamp'
-                    checked:viewstate.showConvTime
-                    enabled: viewstate.loggedin && !viewstate.showConvMin
-                    click: (it) -> action 'showconvtime', it.checked
-                }, {
-                    type: 'checkbox'
-                    label: 'Show Conversation Last Message'
-                    checked:viewstate.showConvLast
-                    enabled: viewstate.loggedin && !viewstate.showConvMin
-                    click: (it) -> action 'showconvlast', it.checked
-                }
-            ]
-
-        }, {
-            type: 'checkbox'
-            label: 'Show Pop-Up (Toast) Notifications'
-            checked: viewstate.showPopUpNotifications
-            enabled: viewstate.loggedin
-            click: (it) -> action 'showpopupnotifications', it.checked
-        }, {
-            type: 'checkbox'
-            label: 'Convert text to emoji'
-            checked: viewstate.convertEmoji
-            enabled: viewstate.loggedin
-            click: (it) -> action 'convertemoji', it.checked
-        }, {
-            label: 'Color Scheme'
-            submenu: [
-                {
-                    label: 'Default'
-                    type: 'radio'
-                    checked: viewstate.colorScheme == 'default'
-                    click: -> action 'changetheme', 'default'
-                }, {
-                    label: 'Blue'
-                    type: 'radio'
-                    checked: viewstate.colorScheme == 'blue'
-                    click: -> action 'changetheme', 'blue'
-                }, {
-                    label: 'Dark'
-                    type: 'radio'
-                    checked: viewstate.colorScheme == 'dark'
-                    click: -> action 'changetheme', 'dark'
-                }, {
-                    label: 'Material'
-                    type: 'radio'
-                    checked: viewstate.colorScheme == 'material'
-                    click: -> action 'changetheme', 'material'
-                }
-            ]
-        },
-         {
-            label: 'Font Size'
-            submenu: [
-                {
-                    label: 'Extra Small'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'x-small'
-                    click: -> action 'changefontsize', 'x-small'
-                }, {
-                    label: 'Small'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'small'
-                    click: -> action 'changefontsize', 'small'
-                }, {
-                    label: 'Medium'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'medium'
-                    click: -> action 'changefontsize', 'medium'
-                }, {
-                    label: 'Large'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'large'
-                    click: -> action 'changefontsize', 'large'
-                }, {
-                    label: 'Extra Large'
-                    type: 'radio'
-                    checked: viewstate.fontSize == 'x-large'
-                    click: -> action 'changefontsize', 'x-large'
-                }
-            ]
-        }, {
-            label: 'Toggle Full Screen',
-            accelerator: 'Control+Alt+F',
-            click: -> action 'togglefullscreen'
-        }, {
-            # seee https://github.com/atom/electron/issues/1507
-            label: 'Zoom In',
-            accelerator: 'Control+Plus',
-            click: -> action 'zoom', +0.25
-        }, {
-            label: 'Zoom Out',
-            accelerator: 'Control+-',
-            click: -> action 'zoom', -0.25
-        }, {
-            label: 'Reset Zoom',
-            accelerator: 'Control+0',
-            click: -> action 'zoom'
-        }, {
-          type: 'separator'
-        }, {
-            label: 'Previous Conversation',
-            accelerator: 'Control+K',
-            click: -> action 'selectNextConv', -1
-            enabled: viewstate.loggedin
-        }, {
-            label: 'Next Conversation',
-            accelerator: 'Control+J',
-            click: -> action 'selectNextConv', +1
-            enabled: viewstate.loggedin
-        }, {
-            label: 'Select Conversation',
-            enabled: viewstate.loggedin
-            submenu: [
-              {
-                label: 'Conversation 1'
-                accelerator: 'Alt+1'
-                click: -> action 'selectConvIndex', 0
-              },
-              {
-                label: 'Conversation 2'
-                accelerator: 'Alt+2'
-                click: -> action 'selectConvIndex', 1
-              },
-              {
-                label: 'Conversation 3'
-                accelerator: 'Alt+3'
-                click: -> action 'selectConvIndex', 2
-              },
-              {
-                label: 'Conversation 4'
-                accelerator: 'Alt+4'
-                click: -> action 'selectConvIndex', 3
-              },
-              {
-                label: 'Conversation 5'
-                accelerator: 'Alt+5'
-                click: -> action 'selectConvIndex', 4
-              },
-              {
-                label: 'Conversation 6'
-                accelerator: 'Alt+6'
-                click: -> action 'selectConvIndex', 5
-              },
-              {
-                label: 'Conversation 7'
-                accelerator: 'Alt+7'
-                click: -> action 'selectConvIndex', 6
-              },
-              {
-                label: 'Conversation 8'
-                accelerator: 'Alt+8'
-                click: -> action 'selectConvIndex', 7
-              },
-              {
-                label: 'Conversation 9'
-                accelerator: 'Alt+9'
-                click: -> action 'selectConvIndex', 8
-              }
-            ]
-        }, {
-          type: 'separator'
-        }, {
-            label: 'Show tray icon'
-            type: 'checkbox'
-            enabled: not viewstate.hidedockicon
-            checked:  viewstate.showtray
-            click: -> action 'toggleshowtray'
-        }
-    ]}
-]
+templateOthers = (viewstate) -> [
+    {
+        label: 'YakYak'
+        submenu: templateYakYak viewstate
+    }, {
+        label: 'Edit'
+        submenu: templateEdit viewstate
+    },{
+        label: 'View'
+        submenu: templateView viewstate
+    }
+  ]
 
 module.exports = (viewstate) ->
-    if require('os').platform() == 'darwin'
+    if os.platform() == 'darwin'
         Menu.setApplicationMenu Menu.buildFromTemplate templateOsx(viewstate)
     else
         Menu.setApplicationMenu Menu.buildFromTemplate templateOthers(viewstate)

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -289,23 +289,22 @@ templateView = (viewstate) ->
         }
     tmpl
 
-templateWindow = (viewstate, os) ->
-    tmpl = [
-        {
-            label: 'Minimize'
-            accelerator: acceleratorMap['minimize'][os]
-            selector: 'performMiniaturize:'
-        }, {
-            label: 'Close'
-            accelerator: acceleratorMap['close'][os]
-            selector: 'performClose:'
-        }, {
-            type: 'separator'
-        }, {
-            label: 'Bring All to Front',
-            selector: 'arrangeInFront:'
-        }
-    ]
+templateWindow = (viewstate) -> [
+    {
+        label: 'Minimize'
+        accelerator: acceleratorMap['minimize'][os]
+        selector: 'performMiniaturize:'
+    }, {
+        label: 'Close'
+        accelerator: acceleratorMap['close'][os]
+        selector: 'performClose:'
+    }, {
+        type: 'separator'
+    }, {
+        label: 'Bring All to Front',
+        selector: 'arrangeInFront:'
+    }
+]
 
 templateMenu = (viewstate) ->
     tmpl = [{

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -311,6 +311,7 @@ templateView = (viewstate, platform) ->
             click: -> action 'toggleshowtray'
         }
     ]
+    #
     if platform == 'darwin'
         tmpl.push {
             label: 'Hide Dock icon'
@@ -359,6 +360,4 @@ templateMenu = (viewstate) ->
     tmpl
 
 module.exports = (viewstate) ->
-    console.log "b4"
     Menu.setApplicationMenu Menu.buildFromTemplate templateMenu(viewstate)
-    console.log "done!"

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -1,70 +1,77 @@
 remote = require('electron').remote
 Menu = remote.Menu
 
+platform = require('os').platform()
+# to reduce number of == comparisons
+isDarwin = platform == 'darwin'
+isNotDarwin = platform != 'darwin'
+
 acceleratorMap = {
-    hideyakyak:           {others: 'Control+H', darwin:'Command+H'}
-    hideothers:           {others: '', darwin:'Command+Shift+H'}
-    showall:              {others: '', darwin:''}
-    openinspector:        {others: 'Control+Alt+I', darwin:'Command+Alt+I'}
-    quit:                 {others: 'Control+Q', darwin:'Command+Q'}
-    undo:                 {others: 'Control+Z', darwin:'Command+Z'}
-    redo:                 {others: 'Control+Shift+Z', darwin:'Command+Shift+Z'}
-    cut:                  {others: '', darwin:'Command+X'}
-    copy:                 {others: '', darwin:'Command+C'}
-    paste:                {others: '', darwin:'Command+V'}
-    selectall:            {others: '', darwin:'Command+A'}
-    togglefullscreen:     {others: 'Control+Alt+F', darwin:'Command+Control+F'}
-    zoomin:               {others: 'Control+Plus', darwin:'Command+Plus'}
-    zoomout:              {others: 'Control+-', darwin:'Command+-'}
-    resetzoom:            {others: 'Control+0', darwin:'Command+0'}
-    previousconversation: {others: 'Control+K', darwin:'Command+Shift+Tab'}
-    nextconversation:     {others: 'Control+J', darwin:'Command+Tab'}
-    conversation1:        {others: 'Alt+1', darwin:'Command+1'}
-    conversation2:        {others: 'Alt+2', darwin:'Command+2'}
-    conversation3:        {others: 'Alt+3', darwin:'Command+3'}
-    conversation4:        {others: 'Alt+4', darwin:'Command+4'}
-    conversation5:        {others: 'Alt+5', darwin:'Command+5'}
-    conversation6:        {others: 'Alt+6', darwin:'Command+6'}
-    conversation7:        {others: 'Alt+7', darwin:'Command+7'}
-    conversation8:        {others: 'Alt+8', darwin:'Command+8'}
-    conversation9:        {others: 'Alt+9', darwin:'Command+9'}
-    minimize:             {others: '', darwin:'Command+M'}
-    close:                {others: '', darwin:'Command+W'}
+    hideyakyak: {default: 'Control+H', darwin:'Command+H'}
+    hideothers: {default: '', darwin:'Command+Shift+H'}
+    showall: {default: '', darwin:''}
+    openinspector: {default: 'Control+Alt+I', darwin:'Command+Alt+I'}
+    quit: {default: 'Control+Q', darwin:'Command+Q'}
+    undo: {default: 'Control+Z', darwin:'Command+Z'}
+    redo: {default: 'Control+Shift+Z', darwin:'Command+Shift+Z'}
+    cut: {default: '', darwin:'Command+X'}
+    copy: {default: '', darwin:'Command+C'}
+    paste: {default: '', darwin:'Command+V'}
+    selectall: {default: '', darwin:'Command+A'}
+    togglefullscreen: {default: 'Control+Alt+F', darwin:'Command+Control+F'}
+    zoomin: {default: 'Control+Plus', darwin:'Command+Plus'}
+    zoomout: {default: 'Control+-', darwin:'Command+-'}
+    resetzoom: {default: 'Control+0', darwin:'Command+0'}
+    previousconversation: {default: 'Control+K', darwin:'Command+Shift+Tab'}
+    nextconversation:  {default: 'Control+J', darwin:'Command+Tab'}
+    conversation1: {default: 'Alt+1', darwin:'Command+1'}
+    conversation2: {default: 'Alt+2', darwin:'Command+2'}
+    conversation3: {default: 'Alt+3', darwin:'Command+3'}
+    conversation4: {default: 'Alt+4', darwin:'Command+4'}
+    conversation5: {default: 'Alt+5', darwin:'Command+5'}
+    conversation6: {default: 'Alt+6', darwin:'Command+6'}
+    conversation7: {default: 'Alt+7', darwin:'Command+7'}
+    conversation8: {default: 'Alt+8', darwin:'Command+8'}
+    conversation9: {default: 'Alt+9', darwin:'Command+9'}
+    minimize: {default: '', darwin:'Command+M'}
+    close: {default: '', darwin:'Command+W'}
 }
 
-templateYakYak = (viewstate, platform) ->
-    tmpl = []
-    if platform == 'darwin'
-        tmpl.push.apply tmpl,  [
-            { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' }
-            #{ type: 'separator' }
-            # { label: 'Preferences...', accelerator: 'Command+,',
-            # click: => delegate.openConfig() }
-            { type: 'separator' }
-        ]
-    tmpl.push {
-        label: 'Hide YakYak'
-        accelerator: acceleratorMap['hideyakyak'][platform]
-        selector: 'hide:' if platform == 'darwin'
-        role: 'minimize' if platform == 'others'
-    }
+getAccelerator = (key) ->
+    if (retVal = acceleratorMap[key][platform])?
+        retVal
+    else
+        acceleratorMap[key]['default']
 
-    if platform == 'darwin'
-        tmpl.push.apply tmpl, [{
+templateYakYak = (viewstate) ->
+
+    [
+        { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' } if isDarwin
+        #{ type: 'separator' }
+        # { label: 'Preferences...', accelerator: 'Command+,',
+        # click: => delegate.openConfig() }
+        { type: 'separator' } if isDarwin
+        {
+            label: 'Hide YakYak'
+            accelerator: getAccelerator('hideyakyak')
+            selector: 'hide:' if isDarwin
+            role: 'minimize' if isNotDarwin
+        }
+        if isDarwin
+            {
                 label: 'Hide Others'
-                accelerator: acceleratorMap['hideother'][platform]
-                selector: 'hideOtherApplications:' if platform == 'darwin'
+                accelerator: getAccelerator('hideother')
+                selector: 'hideOtherApplications:' if isDarwin
             }
+
             {
                 label: 'Show All'
-                selector: 'unhideAllApplications:' if platform == 'darwin'
+                selector: 'unhideAllApplications:' if isDarwin
             }
-        ]
-    tmpl.push.apply tmpl, [
         { type: 'separator' }
         {
             label: 'Open Inspector'
-            accelerator: acceleratorMap['openinspector'][platform]
+            accelerator: getAccelerator('openinspector')
             click: -> action 'devtools'
         }
         { type: 'separator' }
@@ -75,59 +82,55 @@ templateYakYak = (viewstate, platform) ->
         }
         {
             label: 'Quit'
-            accelerator: acceleratorMap['quit'][platform]
+            accelerator: getAccelerator('quit')
             click: -> action 'quit'
         }
-    ]
-    tmpl
+    ].filter (n) -> n != undefined
 
-templateEdit = (viewstate, platform) ->
-    tmpl = [
+templateEdit = (viewstate) ->
+    [
         {
           label: 'Undo'
-          accelerator: acceleratorMap['undo'][platform]
-          selector: 'undo:' if platform == 'darwin'
-          role: 'undo' if platform == 'others'
+          accelerator: getAccelerator('undo')
+          selector: 'undo:' if isDarwin
+          role: 'undo' if isNotDarwin
         }
         {
           label: 'Redo'
-          accelerator: acceleratorMap['redo'][platform]
-          selector: 'redo:' if platform == 'darwin'
-          role: 'redo' if platform == 'others'
+          accelerator: getAccelerator('redo')
+          selector: 'redo:' if isDarwin
+          role: 'redo' if isNotDarwin
         }
-    ]
-    if platform == 'darwin'
-        tmpl.push.apply tmpl, [
-          { type: 'separator' }
-          {
-            label: 'Cut'
-            accelerator: acceleratorMap['cut'][platform]
-            selector: 'cut:' if platform == 'darwin'
-            role: 'cut' if platform == 'others'
-          }
-          {
-            label: 'Copy'
-            accelerator: acceleratorMap['copy'][platform]
-            selector: 'copy:' if platform == 'darwin'
-            role: 'copy' if platform == 'others'
-          }
-          {
-            label: 'Paste'
-            accelerator: acceleratorMap['paste'][platform]
-            selector: 'paste:' if platform == 'darwin'
-            role: 'paste' if platform == 'others'
-          }
-          {
-            label: 'Select All'
-            accelerator: acceleratorMap['selectall'][platform]
-            selector: 'selectAll:' if platform == 'darwin'
-            role: 'selectall' if platform == 'others'
-          }
-        ]
-    tmpl
+        if isDarwin
+            { type: 'separator' }
+            {
+              label: 'Cut'
+              accelerator: getAccelerator('cut')
+              selector: 'cut:' if isDarwin
+              role: 'cut' if isNotDarwin
+            }
+            {
+              label: 'Copy'
+              accelerator: getAccelerator('copy')
+              selector: 'copy:' if isDarwin
+              role: 'copy' if isNotDarwin
+            }
+            {
+              label: 'Paste'
+              accelerator: getAccelerator('paste')
+              selector: 'paste:' if isDarwin
+              role: 'paste' if isNotDarwin
+            }
+            {
+              label: 'Select All'
+              accelerator: getAccelerator('selectall')
+              selector: 'selectAll:' if isDarwin
+              role: 'selectall' if isNotDarwin
+            }
+    ].filter (n) -> n != undefined
 
-templateView = (viewstate, platform) ->
-    tmpl = [
+templateView = (viewstate) ->
+    [
         {
             label: 'Conversation List'
             submenu: [
@@ -232,31 +235,31 @@ templateView = (viewstate, platform) ->
             ]
         }, {
             label: 'Toggle Full Screen',
-            accelerator: acceleratorMap['togglefullscreen'][platform],
+            accelerator: getAccelerator('togglefullscreen'),
             click: -> action 'togglefullscreen'
         }, {
             # seee https://github.com/atom/electron/issues/1507
             label: 'Zoom In',
-            accelerator: acceleratorMap['zoomin'][platform],
+            accelerator: getAccelerator('zoomin'),
             click: -> action 'zoom', +0.25
         }, {
             label: 'Zoom Out',
-            accelerator: acceleratorMap['zoomout'][platform],
+            accelerator: getAccelerator('zoomout'),
             click: -> action 'zoom', -0.25
         }, {
             label: 'Reset Zoom',
-            accelerator: acceleratorMap['resetzoom'][platform],
+            accelerator: getAccelerator('resetzoom'),
             click: -> action 'zoom'
         }, {
             type: 'separator'
         }, {
             label: 'Previous Conversation',
-            accelerator: acceleratorMap['previousconversation'][platform]
+            accelerator: getAccelerator('previousconversation')
             enabled: viewstate.loggedin
             click: -> action 'selectNextConv', -1
         }, {
             label: 'Next Conversation',
-            accelerator: acceleratorMap['nextconversation'][platform]
+            accelerator: getAccelerator('nextconversation')
             enabled: viewstate.loggedin
             click: -> action 'selectNextConv', +1
         }, {
@@ -265,39 +268,39 @@ templateView = (viewstate, platform) ->
             submenu: [
               {
                   label: 'Conversation 1'
-                  accelerator: acceleratorMap['conversation1'][platform]
+                  accelerator: getAccelarator('conversation1')
                   click: -> action 'selectConvIndex', 0
               }, {
                   label: 'Conversation 2'
-                  accelerator: acceleratorMap['conversation2'][platform]
+                  accelerator: getAccelarator('conversation2')
                   click: -> action 'selectConvIndex', 1
               }, {
                   label: 'Conversation 3'
-                  accelerator: acceleratorMap['conversation3'][platform]
+                  accelerator: getAccelarator('conversation3')
                   click: -> action 'selectConvIndex', 2
               }, {
                   label: 'Conversation 4'
-                  accelerator: acceleratorMap['conversation4'][platform]
+                  accelerator: getAccelarator('conversation4')
                   click: -> action 'selectConvIndex', 3
               }, {
                   label: 'Conversation 5'
-                  accelerator: acceleratorMap['conversation5'][platform]
+                  accelerator: getAccelarator('conversation5')
                   click: -> action 'selectConvIndex', 4
               }, {
                   label: 'Conversation 6'
-                  accelerator: acceleratorMap['conversation6'][platform]
+                  accelerator: getAccelarator('conversation6')
                   click: -> action 'selectConvIndex', 5
               }, {
                   label: 'Conversation 7'
-                  accelerator: acceleratorMap['conversation7'][platform]
+                  accelerator: getAccelarator('conversation7')
                   click: -> action 'selectConvIndex', 6
               }, {
                   label: 'Conversation 8'
-                  accelerator: acceleratorMap['conversation8'][platform]
+                  accelerator: getAccelarator('conversation8')
                   click: -> action 'selectConvIndex', 7
               }, {
                   label: 'Conversation 9'
-                  accelerator: acceleratorMap['conversation9'][platform]
+                  accelerator: getAccelarator('conversation9')
                   click: -> action 'selectConvIndex', 8
               }
             ]
@@ -310,56 +313,57 @@ templateView = (viewstate, platform) ->
             checked:  viewstate.showtray
             click: -> action 'toggleshowtray'
         }
-    ]
-    #
-    if platform == 'darwin'
-        tmpl.push {
-            label: 'Hide Dock icon'
-            type: 'checkbox'
-            enabled: viewstate.showtray
-            checked:  viewstate.hidedockicon
-            click: -> action 'togglehidedockicon'
-        }
-    tmpl
+        if isDarwin
+            {
+                label: 'Hide Dock icon'
+                type: 'checkbox'
+                enabled: viewstate.showtray
+                checked:  viewstate.hidedockicon
+                click: -> action 'togglehidedockicon'
+            }
+    ].filter (n) -> n != undefined
 
-templateWindow = (viewstate, platform) -> [
+templateWindow = (viewstate) -> [
     {
         label: 'Minimize'
-        accelerator: acceleratorMap['minimize'][platform]
-        selector: 'performMiniaturize:' if platform == 'darwin'
+        accelerator: getAccelerator('minimize')
+        selector: 'performMiniaturize:' if isDarwin
     }, {
         label: 'Close'
-        accelerator: acceleratorMap['close'][platform]
-        selector: 'performClose:' if platform == 'darwin'
+        accelerator: getAccelerator('close')
+        selector: 'performClose:' if isDarwin
     }, {
         type: 'separator'
     }, {
         label: 'Bring All to Front',
-        selector: 'arrangeInFront:' if platform == 'darwin'
+        selector: 'arrangeInFront:' if isDarwin
     }
 ]
 
+# note: electron framework currently does not support undefined Menu
+#  entries, which requires a filter for undefined at menu/submenu entry
+#  to remove them
+#
+#  [.., undefined, ..., undefined,.. ].filter (n) -> n != undefined
+#
 templateMenu = (viewstate) ->
-    platform = if require('os').platform() == 'darwin' then 'darwin' else
-        'others'
-
-    tmpl = [{
+    [
+        {
             label: 'YakYak'
-            submenu: templateYakYak viewstate, platform
+            submenu: templateYakYak viewstate
         }, {
             label: 'Edit'
-            submenu: templateEdit viewstate, platform
+            submenu: templateEdit viewstate
         },{
             label: 'View'
-            submenu: templateView viewstate, platform
+            submenu: templateView viewstate
         }
-    ]
-    if platform == 'darwin'
-        tmpl.push {
-            label: 'Window'
-            submenu: templateWindow viewstate, platform
-        }
-    tmpl
+        if isDarwin
+            {
+                label: 'Window'
+                submenu: templateWindow viewstate
+            }
+    ].filter (n) -> n != undefined
 
 module.exports = (viewstate) ->
     Menu.setApplicationMenu Menu.buildFromTemplate templateMenu(viewstate)

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -35,7 +35,7 @@ acceleratorMap = {
 templateYakYak = (viewstate, platform) ->
     tmpl = []
     if platform == 'darwin'
-        tmpl.concat [
+        tmpl.push.apply tmpl,  [
             { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' }
             #{ type: 'separator' }
             # { label: 'Preferences...', accelerator: 'Command+,',
@@ -50,7 +50,7 @@ templateYakYak = (viewstate, platform) ->
     }
 
     if platform == 'darwin'
-        tmpl.push [{
+        tmpl.push.apply tmpl, [{
                 label: 'Hide Others'
                 accelerator: acceleratorMap['hideother'][platform]
                 selector: 'hideOtherApplications:' if platform == 'darwin'
@@ -60,7 +60,7 @@ templateYakYak = (viewstate, platform) ->
                 selector: 'unhideAllApplications:' if platform == 'darwin'
             }
         ]
-    tmpl.push [
+    tmpl.push.apply tmpl, [
         { type: 'separator' }
         {
             label: 'Open Inspector'
@@ -97,7 +97,7 @@ templateEdit = (viewstate, platform) ->
         }
     ]
     if platform == 'darwin'
-        tmpl.push [
+        tmpl.push.apply tmpl, [
           { type: 'separator' }
           {
             label: 'Cut'

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -87,11 +87,13 @@ templateEdit = (viewstate, platform) ->
           label: 'Undo'
           accelerator: acceleratorMap['undo'][platform]
           selector: 'undo:' if platform == 'darwin'
+          role: 'undo' if platform == 'others'
         }
         {
           label: 'Redo'
           accelerator: acceleratorMap['redo'][platform]
           selector: 'redo:' if platform == 'darwin'
+          role: 'redo' if platform == 'others'
         }
     ]
     if platform == 'darwin'
@@ -101,21 +103,25 @@ templateEdit = (viewstate, platform) ->
             label: 'Cut'
             accelerator: acceleratorMap['cut'][platform]
             selector: 'cut:' if platform == 'darwin'
+            role: 'cut' if platform == 'others'
           }
           {
             label: 'Copy'
             accelerator: acceleratorMap['copy'][platform]
             selector: 'copy:' if platform == 'darwin'
+            role: 'copy' if platform == 'others'
           }
           {
             label: 'Paste'
             accelerator: acceleratorMap['paste'][platform]
             selector: 'paste:' if platform == 'darwin'
+            role: 'paste' if platform == 'others'
           }
           {
             label: 'Select All'
             accelerator: acceleratorMap['selectall'][platform]
             selector: 'selectAll:' if platform == 'darwin'
+            role: 'selectall' if platform == 'others'
           }
         ]
     tmpl

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -340,7 +340,9 @@ templateWindow = (viewstate, platform) -> [
 ]
 
 templateMenu = (viewstate) ->
-    platform = if require('os').platform() == 'darwin' then 'darwin' else 'others'
+    platform = if require('os').platform() == 'darwin' then 'darwin' else
+        'others'
+
     tmpl = [{
             label: 'YakYak'
             submenu: templateYakYak viewstate, platform

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -2,98 +2,125 @@ remote = require('electron').remote
 Menu = remote.Menu
 
 acceleratorMap = {
-    hideyakyak:           {others: 'Control+H', osx: 'Command+H'}
-    hideothers:           {others: '', osx: 'Command+Shift+H'}
-    showall:              {others: '', osx: ''}
-    openinspector:        {others: 'Control+Alt+I', osx: 'Command+Alt+I'}
-    quit:                 {others: 'Control+Q', osx: 'Command+Q'}
-    undo:                 {others: 'Control+Z', osx: 'Command+Z'}
-    redo:                 {others: 'Control+Shift+Z', osx: 'Command+Shift+Z'}
-    cut:                  {others: '', osx: 'Command+X'}
-    copy:                 {others: '', osx: 'Command+C'}
-    paste:                {others: '', osx: 'Command+V'}
-    selectall:            {others: '', osx: 'Command+A'}
-    togglefullscreen:     {others: 'Control+Alt+F', osx: 'Command+Control+F'}
-    zoomin:               {others: 'Control+Plus', osx: 'Command+Plus'}
-    zoomout:              {others: 'Control+-', osx: 'Command+-'}
-    resetzoom:            {others: 'Control+0', osx: 'Command+0'}
-    previousconversation: {others: 'Control+K', osx: 'Command+Shift+Tab'}
-    nextconversation:     {others: 'Control+J', osx: 'Command+Tab'}
-    conversation1:        {others: 'Alt+1', osx: 'Command+1'}
-    conversation2:        {others: 'Alt+2', osx: 'Command+2'}
-    conversation3:        {others: 'Alt+3', osx: 'Command+3'}
-    conversation4:        {others: 'Alt+4', osx: 'Command+4'}
-    conversation5:        {others: 'Alt+5', osx: 'Command+5'}
-    conversation6:        {others: 'Alt+6', osx: 'Command+6'}
-    conversation7:        {others: 'Alt+7', osx: 'Command+7'}
-    conversation8:        {others: 'Alt+8', osx: 'Command+8'}
-    conversation9:        {others: 'Alt+9', osx: 'Command+9'}
-    minimize:             {others: '', osx: 'Command+M'}
-    close:                {others: '', osx: 'Command+W'}
+    hideyakyak:           {others: 'Control+H', darwin:'Command+H'}
+    hideothers:           {others: '', darwin:'Command+Shift+H'}
+    showall:              {others: '', darwin:''}
+    openinspector:        {others: 'Control+Alt+I', darwin:'Command+Alt+I'}
+    quit:                 {others: 'Control+Q', darwin:'Command+Q'}
+    undo:                 {others: 'Control+Z', darwin:'Command+Z'}
+    redo:                 {others: 'Control+Shift+Z', darwin:'Command+Shift+Z'}
+    cut:                  {others: '', darwin:'Command+X'}
+    copy:                 {others: '', darwin:'Command+C'}
+    paste:                {others: '', darwin:'Command+V'}
+    selectall:            {others: '', darwin:'Command+A'}
+    togglefullscreen:     {others: 'Control+Alt+F', darwin:'Command+Control+F'}
+    zoomin:               {others: 'Control+Plus', darwin:'Command+Plus'}
+    zoomout:              {others: 'Control+-', darwin:'Command+-'}
+    resetzoom:            {others: 'Control+0', darwin:'Command+0'}
+    previousconversation: {others: 'Control+K', darwin:'Command+Shift+Tab'}
+    nextconversation:     {others: 'Control+J', darwin:'Command+Tab'}
+    conversation1:        {others: 'Alt+1', darwin:'Command+1'}
+    conversation2:        {others: 'Alt+2', darwin:'Command+2'}
+    conversation3:        {others: 'Alt+3', darwin:'Command+3'}
+    conversation4:        {others: 'Alt+4', darwin:'Command+4'}
+    conversation5:        {others: 'Alt+5', darwin:'Command+5'}
+    conversation6:        {others: 'Alt+6', darwin:'Command+6'}
+    conversation7:        {others: 'Alt+7', darwin:'Command+7'}
+    conversation8:        {others: 'Alt+8', darwin:'Command+8'}
+    conversation9:        {others: 'Alt+9', darwin:'Command+9'}
+    minimize:             {others: '', darwin:'Command+M'}
+    close:                {others: '', darwin:'Command+W'}
 }
 
-templateYakYak = (viewstate, os) ->
+templateYakYak = (viewstate, platform) ->
     tmpl = []
-    if os == 'darwin'
-        tmpl.push [
+    if platform == 'darwin'
+        tmpl.concat [
             { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' }
             #{ type: 'separator' }
             # { label: 'Preferences...', accelerator: 'Command+,',
             # click: => delegate.openConfig() }
             { type: 'separator' }
         ]
-    tmpl.push [
-        {
-            label: 'Hide YakYak'
-            accelerator: acceleratorMap['hideyakyak'][os]
-            selector: 'hide:'
-        }
-    ]
+    tmpl.push {
+        label: 'Hide YakYak'
+        accelerator: acceleratorMap['hideyakyak'][platform]
+        selector: 'hide:' if platform == 'darwin'
+        role: 'minimize' if platform == 'others'
+    }
 
-    if os == 'darwin'
+    if platform == 'darwin'
         tmpl.push [{
-              label: 'Hide Others'
-              accelerator: acceleratorMap['hideother'][os]
-              selector: 'hideOtherApplications:'
-        }
-        { label: 'Show All', selector: 'unhideAllApplications:' }
+                label: 'Hide Others'
+                accelerator: acceleratorMap['hideother'][platform]
+                selector: 'hideOtherApplications:' if platform == 'darwin'
+            }
+            {
+                label: 'Show All'
+                selector: 'unhideAllApplications:' if platform == 'darwin'
+            }
         ]
     tmpl.push [
-      { type: 'separator' }
-      {
-          label: 'Open Inspector'
-          accelerator: acceleratorMap['openinspector'][os]
-          click: -> action 'devtools'
-      }
-      { type: 'separator' }
-      {
-          label: 'Logout',
-          click: -> action 'logout'
-          enabled: viewstate.loggedin
-      }
-      {
-          label: 'Quit'
-          accelerator: acceleratorMap['quit'][os]
-          click: -> action 'quit'
-      }
-  ]
-
-templateEdit = (viewstate, os) ->
-    tmpl = [
-        { label: 'Undo', accelerator: acceleratorMap['undo'][os], selector: 'undo:' }
-        { label: 'Redo', accelerator: acceleratorMap['redo'][os], selector: 'redo:' }
+        { type: 'separator' }
+        {
+            label: 'Open Inspector'
+            accelerator: acceleratorMap['openinspector'][platform]
+            click: -> action 'devtools'
+        }
+        { type: 'separator' }
+        {
+            label: 'Logout',
+            click: -> action 'logout'
+            enabled: viewstate.loggedin
+        }
+        {
+            label: 'Quit'
+            accelerator: acceleratorMap['quit'][platform]
+            click: -> action 'quit'
+        }
     ]
-    if os == 'darwin'
+    tmpl
+
+templateEdit = (viewstate, platform) ->
+    tmpl = [
+        {
+          label: 'Undo'
+          accelerator: acceleratorMap['undo'][platform]
+          selector: 'undo:' if platform == 'darwin'
+        }
+        {
+          label: 'Redo'
+          accelerator: acceleratorMap['redo'][platform]
+          selector: 'redo:' if platform == 'darwin'
+        }
+    ]
+    if platform == 'darwin'
         tmpl.push [
           { type: 'separator' }
-          { label: 'Cut', accelerator: acceleratorMap['cut'][os], selector: 'cut:' }
-          { label: 'Copy', accelerator: acceleratorMap['copy'][os], selector: 'copy:' }
-          { label: 'Paste', accelerator: acceleratorMap['paste'][os], selector: 'paste:' }
-          { label: 'Select All', accelerator: acceleratorMap['selectall'][os], selector: 'selectAll:' }
+          {
+            label: 'Cut'
+            accelerator: acceleratorMap['cut'][platform]
+            selector: 'cut:' if platform == 'darwin'
+          }
+          {
+            label: 'Copy'
+            accelerator: acceleratorMap['copy'][platform]
+            selector: 'copy:' if platform == 'darwin'
+          }
+          {
+            label: 'Paste'
+            accelerator: acceleratorMap['paste'][platform]
+            selector: 'paste:' if platform == 'darwin'
+          }
+          {
+            label: 'Select All'
+            accelerator: acceleratorMap['selectall'][platform]
+            selector: 'selectAll:' if platform == 'darwin'
+          }
         ]
     tmpl
 
-templateView = (viewstate, os) ->
+templateView = (viewstate, platform) ->
     tmpl = [
         {
             label: 'Conversation List'
@@ -199,31 +226,31 @@ templateView = (viewstate, os) ->
             ]
         }, {
             label: 'Toggle Full Screen',
-            accelerator: acceleratorMap['togglefullscreen'][os],
+            accelerator: acceleratorMap['togglefullscreen'][platform],
             click: -> action 'togglefullscreen'
         }, {
             # seee https://github.com/atom/electron/issues/1507
             label: 'Zoom In',
-            accelerator: acceleratorMap['zoomin'][os],
+            accelerator: acceleratorMap['zoomin'][platform],
             click: -> action 'zoom', +0.25
         }, {
             label: 'Zoom Out',
-            accelerator: acceleratorMap['zoomout'][os],
+            accelerator: acceleratorMap['zoomout'][platform],
             click: -> action 'zoom', -0.25
         }, {
             label: 'Reset Zoom',
-            accelerator: acceleratorMap['resetzoom'][os],
+            accelerator: acceleratorMap['resetzoom'][platform],
             click: -> action 'zoom'
         }, {
             type: 'separator'
         }, {
             label: 'Previous Conversation',
-            accelerator: acceleratorMap['previousconversation'][os]
+            accelerator: acceleratorMap['previousconversation'][platform]
             enabled: viewstate.loggedin
             click: -> action 'selectNextConv', -1
         }, {
             label: 'Next Conversation',
-            accelerator: acceleratorMap['nextconversation'][os]
+            accelerator: acceleratorMap['nextconversation'][platform]
             enabled: viewstate.loggedin
             click: -> action 'selectNextConv', +1
         }, {
@@ -232,39 +259,39 @@ templateView = (viewstate, os) ->
             submenu: [
               {
                   label: 'Conversation 1'
-                  accelerator: acceleratorMap['conversation1'][os]
+                  accelerator: acceleratorMap['conversation1'][platform]
                   click: -> action 'selectConvIndex', 0
               }, {
                   label: 'Conversation 2'
-                  accelerator: acceleratorMap['conversation2'][os]
+                  accelerator: acceleratorMap['conversation2'][platform]
                   click: -> action 'selectConvIndex', 1
               }, {
                   label: 'Conversation 3'
-                  accelerator: acceleratorMap['conversation3'][os]
+                  accelerator: acceleratorMap['conversation3'][platform]
                   click: -> action 'selectConvIndex', 2
               }, {
                   label: 'Conversation 4'
-                  accelerator: acceleratorMap['conversation4'][os]
+                  accelerator: acceleratorMap['conversation4'][platform]
                   click: -> action 'selectConvIndex', 3
               }, {
                   label: 'Conversation 5'
-                  accelerator: acceleratorMap['conversation5'][os]
+                  accelerator: acceleratorMap['conversation5'][platform]
                   click: -> action 'selectConvIndex', 4
               }, {
                   label: 'Conversation 6'
-                  accelerator: acceleratorMap['conversation6'][os]
+                  accelerator: acceleratorMap['conversation6'][platform]
                   click: -> action 'selectConvIndex', 5
               }, {
                   label: 'Conversation 7'
-                  accelerator: acceleratorMap['conversation7'][os]
+                  accelerator: acceleratorMap['conversation7'][platform]
                   click: -> action 'selectConvIndex', 6
               }, {
                   label: 'Conversation 8'
-                  accelerator: acceleratorMap['conversation8'][os]
+                  accelerator: acceleratorMap['conversation8'][platform]
                   click: -> action 'selectConvIndex', 7
               }, {
                   label: 'Conversation 9'
-                  accelerator: acceleratorMap['conversation9'][os]
+                  accelerator: acceleratorMap['conversation9'][platform]
                   click: -> action 'selectConvIndex', 8
               }
             ]
@@ -278,7 +305,7 @@ templateView = (viewstate, os) ->
             click: -> action 'toggleshowtray'
         }
     ]
-    if os == 'darwin'
+    if platform == 'darwin'
         tmpl.push {
             label: 'Hide Dock icon'
             type: 'checkbox'
@@ -288,42 +315,44 @@ templateView = (viewstate, os) ->
         }
     tmpl
 
-templateWindow = (viewstate, os) -> [
+templateWindow = (viewstate, platform) -> [
     {
         label: 'Minimize'
-        accelerator: acceleratorMap['minimize'][os]
-        selector: 'performMiniaturize:'
+        accelerator: acceleratorMap['minimize'][platform]
+        selector: 'performMiniaturize:' if platform == 'darwin'
     }, {
         label: 'Close'
-        accelerator: acceleratorMap['close'][os]
-        selector: 'performClose:'
+        accelerator: acceleratorMap['close'][platform]
+        selector: 'performClose:' if platform == 'darwin'
     }, {
         type: 'separator'
     }, {
         label: 'Bring All to Front',
-        selector: 'arrangeInFront:'
+        selector: 'arrangeInFront:' if platform == 'darwin'
     }
 ]
 
 templateMenu = (viewstate) ->
-    os = if require('os').platform() == 'darwin' then 'darwin' else 'others'
+    platform = if require('os').platform() == 'darwin' then 'darwin' else 'others'
     tmpl = [{
             label: 'YakYak'
-            submenu: templateYakYak viewstate, os
+            submenu: templateYakYak viewstate, platform
         }, {
             label: 'Edit'
-            submenu: templateEdit viewstate, os
+            submenu: templateEdit viewstate, platform
         },{
             label: 'View'
-            submenu: templateView viewstate, os
+            submenu: templateView viewstate, platform
         }
     ]
-    if os == 'darwin'
+    if platform == 'darwin'
         tmpl.push {
             label: 'Window'
-            submenu: templateWindow viewstate, os
+            submenu: templateWindow viewstate, platform
         }
     tmpl
 
 module.exports = (viewstate) ->
+    console.log "b4"
     Menu.setApplicationMenu Menu.buildFromTemplate templateMenu(viewstate)
+    console.log "done!"


### PR DESCRIPTION
I think a change in how the menus are built is necessary, as it requires two copy of each new menu item, **if not with this approach please give feedback and I'll glady implement it** :)

Maintaining duplicate menu entries for OSX and Others could lead to (temporary) missing entries in menu -- when devs can only test in one platform -- and unnecessary duplicate work

### Tests

**I have (manually) tested in Ubuntu:**
- menus are showing
- menus functionality works
- shortcuts work (except for zoom in, all seem to work)

**I haven't tested the OSX and Windows directly**, the menus seem to render as they should in Ubuntu (with platform tricked to be OSX), but that's how far I've gone.

I can test the Windows environment on Monday, but the OSX will have to be someone else :)