### PR TITLE
Add "show popup notifications" option to tray

### DIFF
--- a/src/ui/views/trayicon.coffee
+++ b/src/ui/views/trayicon.coffee
@@ -50,6 +50,8 @@ update = (unreadCount, viewstate) ->
           label: 'Show pop-up notifications'
           type: "checkbox"
           checked: viewstate.showPopUpNotifications
+          # usage of already existing method and implements same logic
+          #  as other toggle... methods
           click: -> action 'showpopupnotifications',
               !viewstate.showPopUpNotifications
         }

--- a/src/ui/views/trayicon.coffee
+++ b/src/ui/views/trayicon.coffee
@@ -47,6 +47,14 @@ update = (unreadCount, viewstate) ->
         }
 
         {
+          label: 'Show pop-up notifications'
+          type: "checkbox"
+          checked: viewstate.showPopUpNotifications
+          click: -> action 'showpopupnotifications',
+              !viewstate.showPopUpNotifications
+        }
+
+        {
             label: "Close to tray"
             type: "checkbox"
             checked: viewstate.closetotray


### PR DESCRIPTION
I think this option should also be available in the tray icon.

If someone is concerned about the visibility of the messages, having to open the main window could be a problem.
