### PR TITLE
Hide the window (close to tray) on all platforms

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -371,15 +371,14 @@ app.on 'ready', ->
             ipcsend n, e
 
     # Emitted when the window is about to close.
-    # For OSX only hides the window if we're not force closing.
+    # Hides the window if we're not force closing.
     mainWindow.on 'close', (ev) ->
-        if process.platform == 'darwin'
-            if mainWindow.isFullScreen()
-                mainWindow.setFullScreen false
-            if not global.forceClose
-                ev.preventDefault()
-                mainWindow.hide()
-                return
+        if mainWindow.isFullScreen()
+            mainWindow.setFullScreen false
+        if not global.forceClose
+            ev.preventDefault()
+            mainWindow.hide()
+            return
 
         mainWindow = null
         quit()


### PR DESCRIPTION
IMHO it should close to tray only if "Close to tray" is checked, but the following patch does not work:
```
diff --git a/src/main.coffee b/src/main.coffee
index 1be3f01..9d8e83f 100644
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -373,7 +373,7 @@ app.on 'ready', ->
     # Emitted when the window is about to close.
     # For OSX only hides the window if we're not force closing.
     mainWindow.on 'close', (ev) ->
-        if process.platform == 'darwin'
+        if viewstate.closetotray
             if mainWindow.isFullScreen()
                 mainWindow.setFullScreen false
             if not global.forceClose
```
It complains about viewstate not defined. If I add viewstate = require './ui/models', it complains about localStorage undefined.