### PR TITLE
Hide the window (close to tray) on all platforms

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -371,15 +371,14 @@ app.on 'ready', ->
             ipcsend n, e
 
     # Emitted when the window is about to close.
-    # For OSX only hides the window if we're not force closing.
+    # Hides the window if we're not force closing.
     mainWindow.on 'close', (ev) ->
-        if process.platform == 'darwin'
-            if mainWindow.isFullScreen()
-                mainWindow.setFullScreen false
-            if not global.forceClose
-                ev.preventDefault()
-                mainWindow.hide()
-                return
+        if mainWindow.isFullScreen()
+            mainWindow.setFullScreen false
+        if not global.forceClose
+            ev.preventDefault()
+            mainWindow.hide()
+            return
 
         mainWindow = null
         quit()


### PR DESCRIPTION
IMHO it should close to tray only if "Close to tray" is checked (smth like if global.closetotray).