### PR TITLE
Image preview when pasting or adding images via selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/yakyak/yakyak",
   "dependencies": {
     "autosize": "^3.0.8",
-    "electron-debug": "^1.0.1",
     "hangupsjs": "^1.3.2",
     "mime-types": "^2.1.12",
     "moment": "^2.10.3",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   "homepage": "https://github.com/yakyak/yakyak",
   "dependencies": {
     "autosize": "^3.0.8",
+    "electron-debug": "^1.0.1",
     "hangupsjs": "^1.3.2",
-    "mmmagic": "^0.4.5",
+    "mime-types": "^2.1.12",
     "moment": "^2.10.3",
     "node-notifier": "^4.2.3",
     "notr": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "autosize": "^3.0.8",
     "hangupsjs": "^1.3.2",
+    "mmmagic": "^0.4.5",
     "moment": "^2.10.3",
     "node-notifier": "^4.2.3",
     "notr": "^1.1.2",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -261,9 +261,8 @@ app.on 'ready', ->
 
     # we want to upload. in the order specified, with retry
     ipc.on 'uploadclipboardimage', seqreq (ev, spec) ->
-        {conv_id, client_generated_id} = spec
+        {pngData, conv_id, client_generated_id} = spec
         file = tmp.fileSync postfix: ".png"
-        pngData = clipboard.readImage().toPng()
         ipcsend 'uploadingimage', {conv_id, client_generated_id, path:file.name}
         Q.Promise (rs, rj) ->
             fs.writeFile file.name, pngData, plug(rs, rj)

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -7,6 +7,7 @@
     animation: spinnerRotate 2s linear infinite;
 }
 .applayout {
+    * {pointer-events: none;}
     display: flex;
     height: 100%;
     > .controls {
@@ -22,6 +23,29 @@
             border-right: 1px solid var(--grey);
         }
     }
+
+    &.dragover > #drop-overlay {
+        display: table;
+        z-index: 1;
+    }
+
+    > #drop-overlay {
+        top: 0;
+        left: 0;
+        display: none;
+        position: absolute;
+        height: 100%;
+        width: 100%;
+        text-align: center;
+        margin-top: auto;
+        background-color: rgba(119, 119, 119, .4);
+        font-size: 5em;
+        & div {
+          display: table-cell;
+          vertical-align: middle;
+        }
+    }
+
     > .leftresize {
         position: fixed;
         top: 0;

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -22,8 +22,12 @@
             border-right: 1px solid var(--grey);
         }
     }
-    &.dragover #drop-overlay {
+    .dragover #drop-overlay {
         display: block;
+    }
+
+    .dragover * {
+      pointer-events: none;
     }
 
     #drop-overlay {

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -37,17 +37,17 @@
         text-align: center;
         margin-top: auto;
         background-color: rgba(119, 119, 119, .4);
-        font-size: 5em;
+        font-size: 4em;
         & div.inner-overlay {
-          display: table;
+          top: 15%;
           height: 70%;
           width: 70%;
+          display: table;
           position: relative;
           margin: auto auto;
-          top: 15%;
           border: 13px dashed rgba(100,100,100,1);
           border-radius: 10px;
-          color: white;
+          color: rgba(100,100,100,1);
           div {
             display: table-cell;
             vertical-align: middle;

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -22,12 +22,12 @@
             border-right: 1px solid var(--grey);
         }
     }
-    &.dragover > #drop-overlay {
+    &.dragover #drop-overlay {
         display: block;
     }
 
-    > #drop-overlay {
-        z-index: 1;
+    #drop-overlay {
+        z-index: 2;
         top: 0;
         left: 0;
         display: none;
@@ -37,16 +37,16 @@
         text-align: center;
         margin-top: auto;
         background-color: rgba(119, 119, 119, .4);
-        font-size: 4em;
+        font-size: 3em;
         & div.inner-overlay {
-          top: 15%;
-          height: 70%;
-          width: 70%;
+          top: ~"calc(var(--headerbarheight) * 1.5 / var(--zoom))";
+          height: 85%;
+          width: 85%;
           display: table;
           position: relative;
           margin: auto auto;
-          border: 13px dashed rgba(100,100,100,1);
-          border-radius: 10px;
+          border: 5px dashed rgba(100,100,100,1);
+          border-radius: 12px;
           color: rgba(100,100,100,1);
           div {
             display: table-cell;
@@ -97,6 +97,7 @@
         }
     }
     > .right {
+        position: relative;
         flex: 1;
         display: flex;
         flex-direction: column;

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -7,7 +7,6 @@
     animation: spinnerRotate 2s linear infinite;
 }
 .applayout {
-    * {pointer-events: none;}
     display: flex;
     height: 100%;
     > .controls {
@@ -23,13 +22,12 @@
             border-right: 1px solid var(--grey);
         }
     }
-
     &.dragover > #drop-overlay {
-        display: table;
-        z-index: 1;
+        display: block;
     }
 
     > #drop-overlay {
+        z-index: 1;
         top: 0;
         left: 0;
         display: none;
@@ -40,9 +38,20 @@
         margin-top: auto;
         background-color: rgba(119, 119, 119, .4);
         font-size: 5em;
-        & div {
-          display: table-cell;
-          vertical-align: middle;
+        & div.inner-overlay {
+          display: table;
+          height: 70%;
+          width: 70%;
+          position: relative;
+          margin: auto auto;
+          top: 15%;
+          border: 13px dashed rgba(100,100,100,1);
+          border-radius: 10px;
+          color: white;
+          div {
+            display: table-cell;
+            vertical-align: middle;
+          }
         }
     }
 

--- a/src/ui/css/yakyak/input.less
+++ b/src/ui/css/yakyak/input.less
@@ -1,5 +1,15 @@
 @button-container-width: 60px;
 
+@keyframes color_change {
+  from { color: rgba(119, 119, 119, .9); }
+  to { color: rgba(119, 119, 119, 1); }
+}
+
+@keyframes color_change_back {
+  from { color: rgba(119, 119, 119, 1); }
+  to { color: rgba(119, 119, 119, .9); }
+}
+
 .input {
     font-family: 'Roboto', "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif, "NotoColorEmoji";
     position: relative;
@@ -11,8 +21,8 @@
         text-align: center;
         div.relative {
             display: inline-block;
-            min-height: 9em;
-            min-width: 6em;
+            min-height: 5em;
+            min-width: 5em;
         }
         //
         position: absolute;
@@ -25,8 +35,13 @@
             transform: translate3d(0, -100%, 0);
         }
         //
+        .after:hover {
+          animation: color_change 1s;
+          color: rgba(119, 119, 119, 1);
+        }
         .after {
-            background-color: rgba(119, 119, 119, .4);
+            animation: color_change_back 1s;
+            cursor: pointer;
             position: absolute;
             width: 100%;
             height: 100%;
@@ -34,11 +49,13 @@
             bottom: 0;
             left: 0;
             text-align: center;
-            color: rgb(0,240,0);
+            color: rgba(119, 119, 119, .9);
             span {
-                top: 30%;
+                top: 50%;
                 position: relative;
                 font-size: 3em;
+                display: block;
+                transform: perspective(1px) translateY(-50%);
             }
         }
         .close-preview {

--- a/src/ui/css/yakyak/input.less
+++ b/src/ui/css/yakyak/input.less
@@ -48,7 +48,6 @@
             cursor: pointer;
         }
         img {
-          text-align: center;
           max-height:22em;
         }
     }

--- a/src/ui/css/yakyak/input.less
+++ b/src/ui/css/yakyak/input.less
@@ -47,9 +47,9 @@
             right: 0;
             cursor: pointer;
         }
-        .img {
+        img {
           text-align: center;
-          max-height:200px;
+          max-height:22em;
         }
     }
 

--- a/src/ui/css/yakyak/input.less
+++ b/src/ui/css/yakyak/input.less
@@ -11,8 +11,8 @@
         text-align: center;
         div.relative {
             display: inline-block;
-            min-height: 5em;
-            min-width: 3em;
+            min-height: 9em;
+            min-width: 6em;
         }
         //
         position: absolute;

--- a/src/ui/css/yakyak/input.less
+++ b/src/ui/css/yakyak/input.less
@@ -4,6 +4,47 @@
     font-family: 'Roboto', "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif, "NotoColorEmoji";
     position: relative;
 
+    #preview-container {
+        padding-top: 1em;
+        background: var(--white);
+        width: 100%;
+        text-align: center;
+        div.relative {
+            display: inline-block;
+        }
+        //
+        position: absolute;
+        z-index: 0;
+        top: 0;
+        transform: translate3d(0, 0, 0);
+        transition: all .3s ease;
+        background: var(--white);
+        &.open{
+            transform: translate3d(0, -100%, 0);
+        }
+        //
+        .after {
+            background-color: rgba(119, 119, 119, .4);
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            text-align: center;
+            color: rgb(0,240,0);
+            span {
+                top: 30%;
+                position: relative;
+                font-size: 3em;
+            }
+        }
+        .img {
+          text-align: center;
+          max-height:200px;
+        }
+    }
+
     span.emoticon {
         display: inline-block;
         width: 30px;
@@ -14,53 +55,56 @@
         cursor: pointer;
     }
 
-    > #emoji-container {
-        position: absolute;
-        z-index: 0;
-        top: 0;
-        transform: translate3d(0, 0, 0);
-        transition: all .3s ease;
-        background: var(--white);
-        &.open{
-            transform: translate3d(0, -100%, 0);
-        }
-        > #emoji-group-selector {
-            overflow-x: scroll;
-            border-bottom: 1px solid var(--lightgrey);
-            height: 33px;
-            margin-left: 5px;
-
-            > .emoticon {
-                height: 32px;
-                padding-bottom:2px;
+    div.relative {
+        position: relative;
+        > #emoji-container {
+            position: absolute;
+            z-index: 0;
+            top: 0;
+            transform: translate3d(0, 0, 0);
+            transition: all .3s ease;
+            background: var(--white);
+            &.open{
+                transform: translate3d(0, -100%, 0);
             }
-            > .emoticon.glow {
-                border-bottom: 2px solid var(--grey);
+            > #emoji-group-selector {
+                overflow-x: scroll;
+                border-bottom: 1px solid var(--lightgrey);
+                height: 33px;
+                margin-left: 5px;
+
+                > .emoticon {
+                    height: 32px;
+                    padding-bottom:2px;
+                }
+                > .emoticon.glow {
+                    border-bottom: 2px solid var(--grey);
+
+                }
 
             }
 
-        }
-
-        > #emoji-group-selector::-webkit-scrollbar {
-            display: none;
-        }
-        > .emoji-selector {
-            height:131px;
-            overflow-y: scroll;
-            border-bottom: 1px solid var(--lightgrey);
-            width: 100%;
-            padding: 5px 2px 5px 5px;
-
-            > .group-content {
+            > #emoji-group-selector::-webkit-scrollbar {
                 display: none;
-                padding: none;
-                margin: none;
             }
-            > .group-content.visible {
-                display: block;
-            }
-        }
+            > .emoji-selector {
+                height:131px;
+                overflow-y: scroll;
+                border-bottom: 1px solid var(--lightgrey);
+                width: 100%;
+                padding: 5px 2px 5px 5px;
 
+                > .group-content {
+                    display: none;
+                    padding: none;
+                    margin: none;
+                }
+                > .group-content.visible {
+                    display: block;
+                }
+            }
+
+        }
     }
 
     > div.input-container {
@@ -69,7 +113,7 @@
         background: var(--white);
         z-index: 1;
         position: relative;
-        height: 49px;
+        min-height: 49px;
         textarea {
             width: 100%;
             resize: vertical;

--- a/src/ui/css/yakyak/input.less
+++ b/src/ui/css/yakyak/input.less
@@ -11,6 +11,8 @@
         text-align: center;
         div.relative {
             display: inline-block;
+            min-height: 5em;
+            min-width: 3em;
         }
         //
         position: absolute;
@@ -38,6 +40,12 @@
                 position: relative;
                 font-size: 3em;
             }
+        }
+        .close-preview {
+            position:absolute;
+            top: 0;
+            right: 0;
+            cursor: pointer;
         }
         .img {
           text-align: center;

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -2,6 +2,8 @@ Client = require 'hangupsjs'
 remote = require('electron').remote
 ipc    = require('electron').ipcRenderer
 
+clipboard = require('electron').clipboard
+
 {entity, conv, viewstate, userinput, connection, convsettings, notify} = require './models'
 {throttle, later, isImg} = require './util'
 
@@ -195,11 +197,14 @@ handle 'uploadimage', (files) ->
 handle 'onpasteimage', ->
     conv_id = viewstate.selectedConv
     return unless conv_id
+    element = document.getElementById 'preview-img'
+    element.src = clipboard.readImage().toDataURL()
+    document.querySelector('#preview-container').classList.toggle('open')
     msg = userinput.buildChatMessage entity.self, 'uploading image…'
     msg.uploadimage = true
     {client_generated_id} = msg
     conv.addChatMessagePlaceholder entity.self.id, msg
-    ipc.send 'uploadclipboardimage', {conv_id, client_generated_id}
+    # ipc.send 'uploadclipboardimage', {conv_id, client_generated_id}
 
 handle 'uploadingimage', (spec) ->
     # XXX this doesn't look very good because the image

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -196,7 +196,7 @@ handle 'uploadimage', (files) ->
         #   see exactly what he is sending. (using the path would require
         #   polling)
         element.src = nativeImage.createFromPath(file.path).toDataURL()
-        document.querySelector('#preview-container').classList.toggle('open')
+        document.querySelector('#preview-container').classList.add('open')
     else
         for file in files
             # only images please
@@ -216,7 +216,7 @@ handle 'uploadimage', (files) ->
 handle 'onpasteimage', ->
     element = document.getElementById 'preview-img'
     element.src = clipboard.readImage().toDataURL()
-    document.querySelector('#preview-container').classList.toggle('open')
+    document.querySelector('#preview-container').classList.add('open')
 
 handle 'uploadpreviewimage', ->
     conv_id = viewstate.selectedConv

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -224,6 +224,7 @@ handle 'uploadimage', (files) ->
 handle 'onpasteimage', ->
     element = document.getElementById 'preview-img'
     element.src = clipboard.readImage().toDataURL()
+    element.src = element.src.replace /image\/png/, 'image/gif'
     document.querySelector('#preview-container').classList.add('open')
 
 handle 'uploadpreviewimage', ->

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -192,6 +192,9 @@ handle 'uploadimage', (files) ->
             notr "Ignoring file of type #{ext}"
             return
         # store image in preview-container and open it
+        #  I think it is better to embed than reference path as user should
+        #   see exactly what he is sending. (using the path would require
+        #   polling)
         element.src = nativeImage.createFromPath(file.path).toDataURL()
         document.querySelector('#preview-container').classList.toggle('open')
     else

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -4,7 +4,7 @@ ipc    = require('electron').ipcRenderer
 
 
 fs = require('fs')
-mmm = require('mmmagic')
+mime = require('mime-types')
 
 clipboard = require('electron').clipboard
 nativeImage = require('electron').nativeImage
@@ -202,13 +202,10 @@ handle 'uploadimage', (files) ->
         fs.readFile file.path, (err, original_data) ->
             binaryImage = new Buffer(original_data, 'binary')
             base64Image = binaryImage.toString('base64')
-            mimeType = new mmm.Magic(mmm.MAGIC_MYME_TYPE)
-            mimeType.detectFile binaryImage, (err, result) ->
-                if err
-                    throw err
-                element.src = 'data:' + result + ';base64,' + base64Image
-                element.data-type = 'url'
-                document.querySelector('#preview-container').classList.add('open')
+            mimeType = mime.lookup file.path
+            element.src = 'data:' + mimeType + ';base64,' + base64Image
+            element.data-type = 'url'
+            document.querySelector('#preview-container').classList.add('open')
     else
         for file in files
             # only images please

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -204,7 +204,6 @@ handle 'uploadimage', (files) ->
             base64Image = binaryImage.toString('base64')
             mimeType = mime.lookup file.path
             element.src = 'data:' + mimeType + ';base64,' + base64Image
-            element.data-type = 'url'
             document.querySelector('#preview-container').classList.add('open')
     else
         for file in files
@@ -225,7 +224,6 @@ handle 'uploadimage', (files) ->
 handle 'onpasteimage', ->
     element = document.getElementById 'preview-img'
     element.src = clipboard.readImage().toDataURL()
-    element.data-type = 'base64'
     document.querySelector('#preview-container').classList.add('open')
 
 handle 'uploadpreviewimage', ->
@@ -237,12 +235,9 @@ handle 'uploadpreviewimage', ->
     conv.addChatMessagePlaceholder entity.self.id, msg
     # find preview element
     element = document.getElementById 'preview-img'
-    # build PNG image from what is on preview
-    if element.data-type == 'base64'
-        pngData = nativeImage.createFromDataURL(element.src).toPNG()
-    else
-        pngData = fs.readFile(element.src)
-    # reset field and close preview pane
+    # build image from what is on preview
+    pngData = element.src.replace /data:image\/(png|jpe?g|gif|svg);base64,/, ''
+    pngData = new Buffer(pngData, 'base64')
     document.querySelector('#preview-container').classList.remove('open')
     document.querySelector('#emoji-container').classList.remove('open')
     element.src = ''

--- a/src/ui/views/applayout.coffee
+++ b/src/ui/views/applayout.coffee
@@ -55,15 +55,27 @@ drag = do ->
         # this enables dragging at all
         ev.preventDefault()
         addClass closest(ev.target, 'dragtarget'), 'dragover'
+        removeClass closest(ev.target, 'dragtarget'), 'drag-timeout'
         ev.dataTransfer.dropEffect = 'copy'
         return false
 
     ondrop = (ev) ->
         ev.preventDefault()
+        removeClass closest(ev.target, 'dragtarget'), 'dragover'
+        removeClass closest(ev.target, 'dragtarget'), 'drag-timeout'
         action 'uploadimage', ev.dataTransfer.files
 
     ondragleave = (ev) ->
-        removeClass closest(ev.target, 'dragtarget'), 'dragover'
+        if !ev.clientX && !ev.clientY
+            # it was firing the leave event while dragging, had to
+            #  use a timeout to check if it was a "real" event
+            #  by remaining out
+            addClass closest(ev.target, 'dragtarget'), 'drag-timeout'
+            setTimeout ->
+                if ev.target.classList.contains('drag-timeout')
+                    removeClass closest(ev.target, 'dragtarget'), 'dragover'
+                    removeClass closest(ev.target, 'dragtarget'), 'drag-timeout'
+            , 200
 
     {ondragover, ondragenter, ondrop, ondragleave}
 
@@ -85,7 +97,6 @@ resize = do ->
 resizers =
     leftResize: (ev) -> action 'leftresize', (Math.max 90, ev.clientX)
 
-
 module.exports = exp = layout ->
     platform = if process.platform is 'darwin' then 'osx' else ''
     div class:'applayout dragtarget ' + platform, drag, resize, ->
@@ -99,6 +110,8 @@ module.exports = exp = layout ->
             div class:'main', region('main'), onscroll: onScroll
             div class:'maininfo', region('maininfo')
             div class:'foot', region('foot')
+        div id: 'drop-overlay', ->
+            div 'Drop image here.'
     attachListeners()
 
 

--- a/src/ui/views/applayout.coffee
+++ b/src/ui/views/applayout.coffee
@@ -72,7 +72,7 @@ drag = do ->
             #  by remaining out
             addClass closest(ev.target, 'dragtarget'), 'drag-timeout'
             setTimeout ->
-                if ev.target.classList.contains('drag-timeout')
+                if closest(ev.target, 'dragtarget').classList.contains('drag-timeout')
                     removeClass closest(ev.target, 'dragtarget'), 'dragover'
                     removeClass closest(ev.target, 'dragtarget'), 'drag-timeout'
             , 200
@@ -111,7 +111,8 @@ module.exports = exp = layout ->
             div class:'maininfo', region('maininfo')
             div class:'foot', region('foot')
         div id: 'drop-overlay', ->
-            div 'Drop image here.'
+            div class: 'inner-overlay', () ->
+                div 'Drop image here.'
     attachListeners()
 
 

--- a/src/ui/views/applayout.coffee
+++ b/src/ui/views/applayout.coffee
@@ -112,7 +112,7 @@ module.exports = exp = layout ->
             div class:'foot', region('foot')
         div id: 'drop-overlay', ->
             div class: 'inner-overlay', () ->
-                div 'Drop image here.'
+                div 'Drop file here.'
     attachListeners()
 
 

--- a/src/ui/views/applayout.coffee
+++ b/src/ui/views/applayout.coffee
@@ -66,16 +66,15 @@ drag = do ->
         action 'uploadimage', ev.dataTransfer.files
 
     ondragleave = (ev) ->
-        if !ev.clientX && !ev.clientY
-            # it was firing the leave event while dragging, had to
-            #  use a timeout to check if it was a "real" event
-            #  by remaining out
-            addClass closest(ev.target, 'dragtarget'), 'drag-timeout'
-            setTimeout ->
-                if closest(ev.target, 'dragtarget').classList.contains('drag-timeout')
-                    removeClass closest(ev.target, 'dragtarget'), 'dragover'
-                    removeClass closest(ev.target, 'dragtarget'), 'drag-timeout'
-            , 200
+        # it was firing the leave event while dragging, had to
+        #  use a timeout to check if it was a "real" event
+        #  by remaining out
+        addClass closest(ev.target, 'dragtarget'), 'drag-timeout'
+        setTimeout ->
+            if closest(ev.target, 'dragtarget').classList.contains('drag-timeout')
+                removeClass closest(ev.target, 'dragtarget'), 'dragover'
+                removeClass closest(ev.target, 'dragtarget'), 'drag-timeout'
+        , 200
 
     {ondragover, ondragenter, ondrop, ondragleave}
 
@@ -99,13 +98,13 @@ resizers =
 
 module.exports = exp = layout ->
     platform = if process.platform is 'darwin' then 'osx' else ''
-    div class:'applayout dragtarget ' + platform, drag, resize, ->
+    div class:'applayout ' + platform, resize, ->
         div class:'left', ->
             div class:'listhead', region('listhead')
             div class:'list', region('left')
             div class:'lfoot', region('lfoot')
         div class:'leftresize', 'data-resize':'leftResize'
-        div class:'right', ->
+        div class:'right dragtarget ', drag, ->
             div id: 'drop-overlay', ->
                 div class: 'inner-overlay', () ->
                     div 'Drop file here.'

--- a/src/ui/views/applayout.coffee
+++ b/src/ui/views/applayout.coffee
@@ -106,13 +106,13 @@ module.exports = exp = layout ->
             div class:'lfoot', region('lfoot')
         div class:'leftresize', 'data-resize':'leftResize'
         div class:'right', ->
+            div id: 'drop-overlay', ->
+                div class: 'inner-overlay', () ->
+                    div 'Drop file here.'
             div class:'convhead', region('convhead')
             div class:'main', region('main'), onscroll: onScroll
             div class:'maininfo', region('maininfo')
             div class:'foot', region('foot')
-        div id: 'drop-overlay', ->
-            div class: 'inner-overlay', () ->
-                div 'Drop file here.'
     attachListeners()
 
 

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -37,38 +37,47 @@ openByDefault = 'people'
 
 module.exports = view (models) ->
     div class:'input', ->
-        div id:'emoji-container', ->
-            div id:'emoji-group-selector', ->
-                for range in emojiCategories
-                    name = range['title']
-                    glow = ''
-                    if name == openByDefault
-                        glow = 'glow'
-                    span id:name+'-button'
-                    , title:name
-                    , class:'emoticon ' + glow
-                    , range['representation']
-                    , onclick: do (name) -> ->
-                        console.log("Opening " + name)
-                        openEmoticonDrawer name
+        div id: 'preview-container', ->
+            div class: 'relative', ->
+                img id: 'preview-img', src: ''
+                div class: 'after material-icons', ->
+                    span ''
+                div class: 'close-preview', ->
+                    span ''
 
-            div class:'emoji-selector', ->
-                for range in emojiCategories
-                    name = range['title']
-                    visible = ''
-                    if name == openByDefault
-                        visible = 'visible'
+        div class: 'relative', ->
+            div id:'emoji-container', ->
+                div id:'emoji-group-selector', ->
+                    for range in emojiCategories
+                        name = range['title']
+                        glow = ''
+                        if name == openByDefault
+                            glow = 'glow'
+                        span id:name+'-button'
+                        , title:name
+                        , class:'emoticon ' + glow
+                        , range['representation']
+                        , onclick: do (name) -> ->
+                            console.log("Opening " + name)
+                            openEmoticonDrawer name
 
-                    span id:name, class:'group-content ' + visible, ->
-                        for emoji in range['range']
-                            if emoji.indexOf("\u200d") >= 0
-                                # FIXME For now, ignore characters that have the "glue" character in them;
-                                # they don't render properly
-                                continue
-                            span class:'emoticon', emoji
-                            , onclick: do (emoji) -> ->
-                                    element = document.getElementById "message-input"
-                                    insertTextAtCursor element, emoji
+                div class:'emoji-selector', ->
+                    for range in emojiCategories
+                        name = range['title']
+                        visible = ''
+                        if name == openByDefault
+                            visible = 'visible'
+
+                        span id:name, class:'group-content ' + visible, ->
+                            for emoji in range['range']
+                                if emoji.indexOf("\u200d") >= 0
+                                    # FIXME For now, ignore characters that have the "glue" character in them;
+                                    # they don't render properly
+                                    continue
+                                span class:'emoticon', emoji
+                                , onclick: do (emoji) -> ->
+                                        element = document.getElementById "message-input"
+                                        insertTextAtCursor element, emoji
 
         div class:'input-container', ->
             textarea id:'message-input', autofocus:true, placeholder:'Message', rows: 1, ''

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -41,7 +41,9 @@ module.exports = view (models) ->
             div class: 'relative'
                 , onclick: (e) ->
                     console.log 'going to upload preview image'
-                    action 'uploadpreviewimage'
+                    element = document.getElementById "message-input"
+                    # send text
+                    preparemessage element
                 , ->
                     img id: 'preview-img', src: ''
                     div class: 'after material-icons'
@@ -106,17 +108,7 @@ module.exports = view (models) ->
                         action 'hideWindow'
                     if e.keyCode == 13
                         e.preventDefault()
-                        if models.viewstate.convertEmoji
-                            # before sending message, check for emoji
-                            element = document.getElementById "message-input"
-                            # Converts emojicodes (e.g. :smile:, :-) ) to unicode
-                            element.value = convertEmoji(element.value)
-                        #
-                        action 'sendmessage', e.target.value
-                        document.querySelector('#emoji-container').classList.remove('open');
-                        historyPush e.target.value
-                        e.target.value = ''
-                        autosize.update e.target
+                        preparemessage e.target
                     if e.target.value == ''
                         if e.keyIdentifier is "Up" then historyWalk e.target, -1
                         if e.keyIdentifier is "Down" then historyWalk e.target, +1
@@ -170,6 +162,24 @@ maybeFocus = ->
         # steal it!!!
         el = document.querySelector('.input textarea')
         el.focus() if el
+
+preparemessage = (ev) ->
+    if models.viewstate.convertEmoji
+        # before sending message, check for emoji
+        element = document.getElementById "message-input"
+        # Converts emojicodes (e.g. :smile:, :-) ) to unicode
+        element.value = convertEmoji(element.value)
+    #
+    action 'sendmessage', ev.value
+    #
+    # check if there is an image in preview
+    img = document.getElementById "preview-img"
+    action 'uploadpreviewimage' if img.getAttribute('src') != ''
+    #
+    document.querySelector('#emoji-container').classList.remove('open');
+    historyPush ev.value
+    ev.value = ''
+    autosize.update ev
 
 handle 'noinputkeydown', (ev) ->
     el = document.querySelector('.input textarea')

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -56,7 +56,7 @@ module.exports = view (models) ->
                     img id: 'preview-img', src: ''
                     div class: 'after material-icons'
                         , ->
-                          span ''
+                            span 'send'
 
         div class: 'relative', ->
             div id:'emoji-container', ->

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -38,6 +38,14 @@ openByDefault = 'people'
 module.exports = view (models) ->
     div class:'input', ->
         div id: 'preview-container', ->
+            div class: 'close-preview material-icons'
+                , onclick: (e) ->
+                    element = document.getElementById 'preview-img'
+                    element.src = ''
+                    document.querySelector('#preview-container')
+                        .classList.toggle('open')
+                , ->
+                    span ''
             div class: 'relative'
                 , onclick: (e) ->
                     console.log 'going to upload preview image'
@@ -49,8 +57,6 @@ module.exports = view (models) ->
                     div class: 'after material-icons'
                         , ->
                           span ''
-                    div class: 'close-preview', ->
-                        span ''
 
         div class: 'relative', ->
             div id:'emoji-container', ->
@@ -134,7 +140,7 @@ module.exports = view (models) ->
 
             span class:'button-container', ->
                 button title:'Show emoticons', onclick: (ef) ->
-                    document.querySelector('#emoji-container').classList.toggle('open');
+                    document.querySelector('#emoji-container').classList.toggle('open')
                     scrollToBottom()
                 , ->
                     span class:'material-icons', "mood"

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -43,7 +43,7 @@ module.exports = view (models) ->
                     element = document.getElementById 'preview-img'
                     element.src = ''
                     document.querySelector('#preview-container')
-                        .classList.toggle('open')
+                        .classList.remove('open')
                 , ->
                     span ''
             div class: 'relative'

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -38,12 +38,17 @@ openByDefault = 'people'
 module.exports = view (models) ->
     div class:'input', ->
         div id: 'preview-container', ->
-            div class: 'relative', ->
-                img id: 'preview-img', src: ''
-                div class: 'after material-icons', ->
-                    span ''
-                div class: 'close-preview', ->
-                    span ''
+            div class: 'relative'
+                , onclick: (e) ->
+                    console.log 'going to upload preview image'
+                    action 'uploadpreviewimage'
+                , ->
+                    img id: 'preview-img', src: ''
+                    div class: 'after material-icons'
+                        , ->
+                          span ''
+                    div class: 'close-preview', ->
+                        span ''
 
         div class: 'relative', ->
             div id:'emoji-container', ->


### PR DESCRIPTION
This improves current functionality and is only implemented when pasting images.

It allows to paste image and send both the image and current text with "enter" or clicking the image.

![output](https://cloud.githubusercontent.com/assets/211358/18879066/ebfcbd40-84ca-11e6-9199-110549ff20db.gif)
### Open questions / TODO
- **Done** _see comment below_: How to do this with multiple images? Once we figure this one out, I guess it becomes mergeable
  - The image selector allows to upload multiple images and that is why It is not implemented yet
- How to allow pasting even when input is not selected
  - Should we have a system wide event handler for pasting that always  paste to conversation (if conversation is the active interface)
- I don't like the fact that this implementation requires a div over 'emoji container', but otherwise it would have a conflict with it
### Testing

I've done some testing, but need further :)

edit1: adds figure
edit2: mark first point of TODO as done and changed title
