### PR TITLE
[DO NOT MERGE] Switching between hide window and clear input when pressing 'escape' key

### DIFF
--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -117,8 +117,8 @@ handle 'togglemenu', ->
     mainWindow = remote.getCurrentWindow()
     if mainWindow.isMenuBarVisible() then mainWindow.setMenuBarVisibility(false) else mainWindow.setMenuBarVisibility(true)
 
-handle 'toggleescapecloseswindow', ->
-    viewstate.setEscapeClosesWindow(not viewstate.escapeClosesWindow)
+handle 'setescapeclearsinput', (value) ->
+    viewstate.setEscapeClearsInput(value)
 
 handle 'togglehidedockicon', ->
     viewstate.setHideDockIcon(not viewstate.hidedockicon)

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -117,6 +117,9 @@ handle 'togglemenu', ->
     mainWindow = remote.getCurrentWindow()
     if mainWindow.isMenuBarVisible() then mainWindow.setMenuBarVisibility(false) else mainWindow.setMenuBarVisibility(true)
 
+handle 'toggleescapecloseswindow', ->
+    viewstate.setEscapeClosesWindow(not viewstate.escapeClosesWindow)
+
 handle 'togglehidedockicon', ->
     viewstate.setHideDockIcon(not viewstate.hidedockicon)
 

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -29,6 +29,7 @@ module.exports = exp = {
     fontSize: localStorage.fontSize or 'medium'
     zoom: tryparse(localStorage.zoom ? "1.0")
     loggedin: false
+    escapeClosesWindow: tryparse(localStorage.escapeClosesWindow) or true
     showtray: tryparse(localStorage.showtray) or false
     hidedockicon: tryparse(localStorage.hidedockicon) or false
     startminimizedtotray: tryparse(localStorage.startminimizedtotray) or false
@@ -138,7 +139,7 @@ module.exports = exp = {
                         action 'settyping', STOPPED
                     , 6000
                 , 6000
-    
+
     setShowConvMin: (doshow) ->
         return if @showConvMin == doshow
         @showConvMin = localStorage.showConvMin = doshow
@@ -190,6 +191,12 @@ module.exports = exp = {
             document.querySelector('html').classList.remove document.querySelector('html').classList.item(0)
         document.querySelector('html').classList.add(localStorage.colorScheme)
         document.querySelector('html').classList.add(fontsize)
+
+    setEscapeClosesWindow: (value) ->
+        @escapeClosesWindow = localStorage.escapeClosesWindow = value
+        if @escapeClosesWindow
+            @setEscapeClearsInput(false)
+        updated 'viewstate'
 
     setShowTray: (value) ->
         @showtray = localStorage.showtray = value

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -29,7 +29,7 @@ module.exports = exp = {
     fontSize: localStorage.fontSize or 'medium'
     zoom: tryparse(localStorage.zoom ? "1.0")
     loggedin: false
-    escapeClosesWindow: tryparse(localStorage.escapeClosesWindow) or true
+    escapeClearsInput: tryparse(localStorage.escapeClearsInput) or false
     showtray: tryparse(localStorage.showtray) or false
     hidedockicon: tryparse(localStorage.hidedockicon) or false
     startminimizedtotray: tryparse(localStorage.startminimizedtotray) or false
@@ -192,10 +192,8 @@ module.exports = exp = {
         document.querySelector('html').classList.add(localStorage.colorScheme)
         document.querySelector('html').classList.add(fontsize)
 
-    setEscapeClosesWindow: (value) ->
-        @escapeClosesWindow = localStorage.escapeClosesWindow = value
-        if @escapeClosesWindow
-            @setEscapeClearsInput(false)
+    setEscapeClearsInput: (value) ->
+        @escapeClearsInput = localStorage.escapeClearsInput = value
         updated 'viewstate'
 
     setShowTray: (value) ->

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -87,7 +87,7 @@ module.exports = view (models) ->
                 if (e.metaKey or e.ctrlKey) and e.keyIdentifier == 'Up' then action 'selectNextConv', -1
                 if (e.metaKey or e.ctrlKey) and e.keyIdentifier == 'Down' then action 'selectNextConv', +1
                 unless isModifierKey(e)
-                    if e.keyCode == 27
+                    if e.keyCode == 27 && models.viewstate.showtray && models.viewstate.escapeClosesWindow
                         e.preventDefault()
                         action 'hideWindow'
                     if e.keyCode == 13

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -87,9 +87,17 @@ module.exports = view (models) ->
                 if (e.metaKey or e.ctrlKey) and e.keyIdentifier == 'Up' then action 'selectNextConv', -1
                 if (e.metaKey or e.ctrlKey) and e.keyIdentifier == 'Down' then action 'selectNextConv', +1
                 unless isModifierKey(e)
-                    if e.keyCode == 27 && models.viewstate.showtray && models.viewstate.escapeClosesWindow
+                    if e.keyCode == 27
                         e.preventDefault()
-                        action 'hideWindow'
+                        if models.viewstate.showtray && !models.viewstate.escapeClearsInput
+                            action 'hideWindow'
+                        else
+                            # must focus on field and then execute:
+                            #  - select all text in input
+                            #  - replace them with an empty string
+                            document.getElementById("message-input").focus()
+                            document.execCommand("selectAll", false)
+                            document.execCommand("insertText", false, "")
                     if e.keyCode == 13
                         e.preventDefault()
                         if models.viewstate.convertEmoji

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -312,6 +312,12 @@ templateView = (viewstate) ->
             enabled: not viewstate.hidedockicon
             checked:  viewstate.showtray
             click: -> action 'toggleshowtray'
+        }, {
+          label: 'Escape key hides YakYak to tray'
+          type: 'checkbox'
+          enabled: viewstate.showtray
+          checked: viewstate.escapeClosesWindow
+          click: -> action 'toggleescapecloseswindow'
         }
         if isDarwin
             {

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -313,7 +313,7 @@ templateView = (viewstate) ->
             checked:  viewstate.showtray
             click: -> action 'toggleshowtray'
         }, {
-          label: 'Pressing escape...'
+          label: 'Escape key behavior'
           submenu: [
               {
                   label: 'Hides window'

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -313,11 +313,23 @@ templateView = (viewstate) ->
             checked:  viewstate.showtray
             click: -> action 'toggleshowtray'
         }, {
-          label: 'Escape key hides YakYak to tray'
-          type: 'checkbox'
-          enabled: viewstate.showtray
-          checked: viewstate.escapeClosesWindow
-          click: -> action 'toggleescapecloseswindow'
+          label: 'Pressing escape...'
+          submenu: [
+              {
+                  label: 'Hides window'
+                  type: 'checkbox'
+                  enabled: viewstate.showtray
+                  checked: viewstate.showtray && !viewstate.escapeClearsInput
+                  click: -> action 'setescapeclearsinput', false
+              }
+              {
+                  label: 'Clears input' + if !viewstate.showtray then ' (default when tray is not showing)'
+                  type: 'checkbox'
+                  enabled: viewstate.showtray
+                  checked: !viewstate.showtray || viewstate.escapeClearsInput
+                  click: -> action 'setescapeclearsinput', true
+              }
+          ]
         }
         if isDarwin
             {

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -317,14 +317,14 @@ templateView = (viewstate) ->
           submenu: [
               {
                   label: 'Hides window'
-                  type: 'checkbox'
+                  type: 'radio'
                   enabled: viewstate.showtray
                   checked: viewstate.showtray && !viewstate.escapeClearsInput
                   click: -> action 'setescapeclearsinput', false
               }
               {
-                  label: 'Clears input' + if !viewstate.showtray then ' (default when tray is not showing)'
-                  type: 'checkbox'
+                  label: 'Clears input' + if !viewstate.showtray then ' (default when tray is not showing)' else ''
+                  type: 'radio'
                   enabled: viewstate.showtray
                   checked: !viewstate.showtray || viewstate.escapeClearsInput
                   click: -> action 'setescapeclearsinput', true


### PR DESCRIPTION
This is perhaps a very personal workflow, but I expect the text to be cleared when pressing the escape key (closing the window should be with alt+f4 or 'x' button on window)

This preserves history of input, as 'undo' will return previous cleared text
### Before merging this PR I have 1 question
1. This option defaults to 'clear input' when 'show icon in tray' is not selected
   - When the window disappears and I see no tray icon it is not obvious to me that the app is still running in background (this is the behavior in Linux/Ubuntu)... 

**Quesiton for OSX users: do you still see the icon somewhere?**

Screenshot below shows that radio buttons are not enabled and defaults to clear input when 'show tray' is not active.

![image](https://cloud.githubusercontent.com/assets/211358/19193844/a29f70bc-8ca3-11e6-92f0-991febe1d831.png)
### Example

Screencast shows an example of how it works. The option is available in View -> Escape behavior -> Hide window / Clear input radio buttons

![outqboumbfon6](https://cloud.githubusercontent.com/assets/211358/19193610/98fd9792-8ca2-11e6-85bb-5e962d7a8f7d.gif)

ps. I took the screenshots with my dev build that includes @arnriu's link snippet feature and @mliq popup privacy notifications (still dev).. ignore all 'unkown' options seen in screenchot/screencast as they are not included in the PR request
