### PR TITLE
'Help -> About' window

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -401,4 +401,5 @@ app.on 'ready', ->
                 mainWindow.hide()
                 return
 
+        mainWindow = null
         quit()

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -112,6 +112,15 @@ app.on 'ready', ->
         autoHideMenuBar : true unless process.platform is 'darwin'
     }
 
+    aboutWindow = new BrowserWindow {
+      width: 500
+      height: 500
+      show: false
+      modal: true
+      parent: mainWindow
+    }
+
+    aboutWindow.loadURL 'file://' + __dirname + '/ui/about.html'
 
     # and load the index.html of the app. this may however be yanked
     # away if we must do auth.
@@ -365,10 +374,22 @@ app.on 'ready', ->
 
     ipc.on 'quit', quit
 
+    # Help -> About opens the about window
+    ipc.on 'show-about', ->
+        aboutWindow.setMenu(null)
+        aboutWindow.show()
+
     # propagate these events to the renderer
     require('./ui/events').forEach (n) ->
         client.on n, (e) ->
             ipcsend n, e
+
+    # Emitted when about window is about to close and prevents it,
+    #  instead it hides the window.
+    aboutWindow.on 'close', (ev) ->
+        aboutWindow.hide()
+        ev.preventDefault()
+        return false
 
     # Emitted when the window is about to close.
     # For OSX only hides the window if we're not force closing.
@@ -381,5 +402,4 @@ app.on 'ready', ->
                 mainWindow.hide()
                 return
 
-        mainWindow = null
         quit()

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -116,7 +116,6 @@ app.on 'ready', ->
       width: 500
       height: 500
       show: false
-      modal: true
       parent: mainWindow
     }
 

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -121,6 +121,7 @@ app.on 'ready', ->
       height: 500
       show: false
       parent: mainWindow
+      resizable: false
     }
 
     aboutWindow.loadURL 'file://' + __dirname + '/ui/about.html'

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -49,6 +49,7 @@ logout = ->
 seqreq = require './seqreq'
 
 mainWindow = null
+aboutWindow = null
 
 # Only allow a single active instance
 shouldQuit = app.makeSingleInstance ->
@@ -62,7 +63,10 @@ if shouldQuit
 # No more minimizing to tray, just close it
 global.forceClose = false;
 quit = ->
-    global.forceClose = true;
+    global.forceClose = true
+    # force all windows to close
+    aboutWindow.destroy()
+    mainWindow.destroy()
     app.quit()
     return
 

--- a/src/ui/about.coffee
+++ b/src/ui/about.coffee
@@ -1,0 +1,21 @@
+ipc       = require('electron').ipcRenderer
+path = require 'path'
+
+remote = require('electron').remote
+
+trifl = require 'trifl'
+
+# expose some selected tagg functions
+trifl.tagg.expose window, ('ul li div span a i b u s button p label
+input table thead tbody tr td th textarea br pass img h1 h2 h3 h4
+hr em'.split(' '))...
+
+{applayout, aboutlayout} = require './views'
+
+document.body.appendChild aboutlayout.el
+
+link_out = (ev)->
+    ev.preventDefault()
+    address = e.currentTarget.getAttribute 'href'
+    require('electron').shell.openExternal address
+    false

--- a/src/ui/about.html
+++ b/src/ui/about.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>YakYak</title>
+    <link rel="stylesheet" href="app.css">
+  </head>
+  <body>
+    <script src="about.js"></script>
+  </body>
+</html>

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -6,6 +6,19 @@
 .spin{
     animation: spinnerRotate 2s linear infinite;
 }
+
+.about {
+    margin-top: 3em;
+    margin-bottom: 3em;
+    text-align: center;
+    img {
+        height: 4em;
+    }
+    div {
+        margin-bottom: .5em;
+    }
+}
+
 .applayout {
     display: flex;
     height: 100%;

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -120,6 +120,9 @@ handle 'togglemenu', ->
 handle 'togglehidedockicon', ->
     viewstate.setHideDockIcon(not viewstate.hidedockicon)
 
+handle 'show-about', ->
+    ipc.send 'show-about'
+
 handle 'hideWindow', ->
     mainWindow = remote.getCurrentWindow() # And we hope we don't get another ;)
     mainWindow.hide()

--- a/src/ui/version.coffee
+++ b/src/ui/version.coffee
@@ -10,7 +10,7 @@ versionToInt = (version) ->
     [major, minor, micro] = version.split('.')
     version = (micro * 10^3) + (minor * 10^6) + (major * 10^9)
 
-check = (noConsole = false)->
+check = (noAlert = false)->
     request.get options,  (err, res, body) ->
         return console.log err if err
         body = JSON.parse body
@@ -18,11 +18,14 @@ check = (noConsole = false)->
         releasedVersion = tag.substr(1) # remove first "v" char
         localVersion = require('electron').remote.require('electron').app.getVersion()
         versionAdvertised = window.localStorage.versionAdvertised or null
-        higherVersionAvailable = versionToInt(releasedVersion) < versionToInt(localVersion)
-        if higherVersionAvailable and (releasedVersion isnt versionAdvertised)
-            window.localStorage.versionAdvertised = releasedVersion
-            alert "A new yakyak version is available, please upgrade #{localVersion} to #{releasedVersion}"
-        else
-            console.log "YakYak local version is #{localVersion}, released version is #{releasedVersion}"
+        if releasedVersion? && localVersion?
+            higherVersionAvailable = versionToInt(releasedVersion) > versionToInt(localVersion)
+            if higherVersionAvailable and (releasedVersion isnt versionAdvertised)
+                window.localStorage.versionAdvertised = releasedVersion
+                unless noAlert
+                    alert "A new yakyak version is available, please upgrade #{localVersion} to #{releasedVersion}"
+            else
+                unless noAlert
+                    console.log "YakYak local version is #{localVersion}, released version is #{releasedVersion}"
 
 module.exports = {check, versionToInt}

--- a/src/ui/version.coffee
+++ b/src/ui/version.coffee
@@ -2,27 +2,27 @@
 request = require 'request'
 
 options =
-  headers:
-    'User-Agent': 'request'
-  url: 'https://api.github.com/repos/yakyak/yakyak/releases/latest'
+    headers:
+      'User-Agent': 'request'
+    url: 'https://api.github.com/repos/yakyak/yakyak/releases/latest'
 
 versionToInt = (version) ->
-  [major, minor, micro] = version.split('.')
-  version = (micro * 10^3) + (minor * 10^6) + (major * 10^9)
+    [major, minor, micro] = version.split('.')
+    version = (micro * 10^3) + (minor * 10^6) + (major * 10^9)
 
-check = ->
-  request.get options,  (err, res, body) ->
-    return console.log err if err
-    body = JSON.parse body
-    tag = body.tag_name
-    releasedVersion = tag.substr(1) # remove first "v" char
-    localVersion = require('electron').remote.require('electron').app.getVersion()
-    versionAdvertised = window.localStorage.versionAdvertised or null
-    higherVersionAvailable = versionToInt(releasedVersion) > versionToInt(localVersion)
-    if higherVersionAvailable and (releasedVersion isnt versionAdvertised)
-      window.localStorage.versionAdvertised = releasedVersion
-      alert "A new yakyak version is available, please upgrade #{localVersion} to #{releasedVersion}"
-    else
-      console.log "YakYak local version is #{localVersion}, released version is #{releasedVersion}"
+check = (noConsole = false)->
+    request.get options,  (err, res, body) ->
+        return console.log err if err
+        body = JSON.parse body
+        tag = body.tag_name
+        releasedVersion = tag.substr(1) # remove first "v" char
+        localVersion = require('electron').remote.require('electron').app.getVersion()
+        versionAdvertised = window.localStorage.versionAdvertised or null
+        higherVersionAvailable = versionToInt(releasedVersion) < versionToInt(localVersion)
+        if higherVersionAvailable and (releasedVersion isnt versionAdvertised)
+            window.localStorage.versionAdvertised = releasedVersion
+            alert "A new yakyak version is available, please upgrade #{localVersion} to #{releasedVersion}"
+        else
+            console.log "YakYak local version is #{localVersion}, released version is #{releasedVersion}"
 
-module.exports = {check}
+module.exports = {check, versionToInt}

--- a/src/ui/views/aboutlayout.coffee
+++ b/src/ui/views/aboutlayout.coffee
@@ -17,6 +17,7 @@ attachListeners = ->
     return
     # do nothing
 
+check(true)
 releasedVersion = window.localStorage.versionAdvertised
 localVersion = remote.require('electron').app.getVersion()
 

--- a/src/ui/views/aboutlayout.coffee
+++ b/src/ui/views/aboutlayout.coffee
@@ -27,7 +27,11 @@ module.exports = exp = layout ->
             img src: path.join __dirname, '..', '..', 'icons', 'yakyak-logo.svg'
         div class: 'name', ->
             h2 'YakYak v' + localVersion
-        if (versionToInt(releasedVersion) > versionToInt(localVersion))
+        # TODO: if objects are undefined then it should check again on next
+        #        time about window is opened
+        if (releasedVersion? &&
+            localVersion? &&
+            versionToInt(releasedVersion) > versionToInt(localVersion))
             div class: 'update', ->
                 span 'A newer version is available, please upgrade from ' +
                      localVersion + ' to ' + releasedVersion

--- a/src/ui/views/aboutlayout.coffee
+++ b/src/ui/views/aboutlayout.coffee
@@ -1,0 +1,64 @@
+ipc  = require('electron').ipcRenderer
+path = require 'path'
+
+remote = require('electron').remote
+
+{check, versionToInt} = require '../version'
+
+trifl = require 'trifl'
+trifl.expose window
+
+# expose some selected tagg functions
+trifl.tagg.expose window, ('ul li div span a i b u s button p label
+input table thead tbody tr td th textarea br pass img h1 h2 h3 h4
+hr em'.split(' '))...
+
+attachListeners = ->
+    return
+    # do nothing
+
+releasedVersion = window.localStorage.versionAdvertised
+localVersion = remote.require('electron').app.getVersion()
+
+module.exports = exp = layout ->
+    div class: 'about', ->
+        div ->
+            img src: path.join __dirname, '..', '..', 'icons', 'yakyak-logo.svg'
+        div class: 'name', ->
+            h2 'YakYak v' + localVersion
+        if (versionToInt(releasedVersion) > versionToInt(localVersion))
+            div class: 'update', ->
+                span 'A newer version is available, please upgrade from ' +
+                     localVersion + ' to ' + releasedVersion
+        div class: 'description', ->
+            span 'Desktop client for Google Hangouts'
+        div class: 'license', ->
+            span ->
+                em 'License: '
+                span 'MIT'
+        div class: 'devs', ->
+            div ->
+                h3 'Main authors'
+                ul ->
+                    li 'Davide Bertola'
+                    li 'Martin Algesten'
+            div ->
+                h3 'Contributors'
+                ul ->
+                    li 'David Banham'
+                    li 'Max Kueng'
+                    li 'Arnaud Riu'
+                    li 'Austin Guevara'
+        div class: 'home', ->
+            href = "https://github/yakyak/yakyak"
+            a href: href
+            , onclick: (ev) ->
+                ev.preventDefault()
+                address = ev.currentTarget.getAttribute 'href'
+                require('electron').shell.openExternal address
+                false
+            , href
+    attachListeners()
+
+#$('document').on 'click', '.link-out', (ev)->
+#

--- a/src/ui/views/aboutlayout.coffee
+++ b/src/ui/views/aboutlayout.coffee
@@ -29,9 +29,7 @@ module.exports = exp = layout ->
             h2 'YakYak v' + localVersion
         # TODO: if objects are undefined then it should check again on next
         #        time about window is opened
-        if (releasedVersion? &&
-            localVersion? &&
-            versionToInt(releasedVersion) > versionToInt(localVersion))
+        if releasedVersion? && localVersion? && versionToInt(releasedVersion) > versionToInt(localVersion)
             div class: 'update', ->
                 span 'A newer version is available, please upgrade from ' +
                      localVersion + ' to ' + releasedVersion

--- a/src/ui/views/aboutlayout.coffee
+++ b/src/ui/views/aboutlayout.coffee
@@ -51,7 +51,7 @@ module.exports = exp = layout ->
                     li 'Arnaud Riu'
                     li 'Austin Guevara'
         div class: 'home', ->
-            href = "https://github/yakyak/yakyak"
+            href = "https://github.com/yakyak/yakyak"
             a href: href
             , onclick: (ev) ->
                 ev.preventDefault()

--- a/src/ui/views/index.coffee
+++ b/src/ui/views/index.coffee
@@ -1,4 +1,5 @@
 module.exports =
+    aboutlayout: require './aboutlayout'
     applayout: require './applayout'
     convlist:  require './convlist'
     listhead:  require './listhead'

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -46,7 +46,10 @@ getAccelerator = (key) ->
 templateYakYak = (viewstate) ->
 
     [
-        { label: 'About YakYak', selector: 'orderFrontStandardAboutPanel:' } if isDarwin
+        {
+            label: 'About YakYak',
+            click: (it) -> action 'show-about'
+        } if isDarwin
         #{ type: 'separator' }
         # { label: 'Preferences...', accelerator: 'Command+,',
         # click: => delegate.openConfig() }
@@ -365,7 +368,7 @@ templateMenu = (viewstate) ->
               click: () -> action 'show-about'
             }
           ]
-        }
+        } if isDarwin
         if isDarwin
             {
                 label: 'Window'

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -369,11 +369,10 @@ templateMenu = (viewstate) ->
             }
           ]
         } if isDarwin
-        if isDarwin
-            {
-                label: 'Window'
-                submenu: templateWindow viewstate
-            }
+        {
+            label: 'Window'
+            submenu: templateWindow viewstate
+        } if isDarwin
 
     ].filter (n) -> n != undefined
 

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -363,6 +363,15 @@ templateMenu = (viewstate) ->
                 label: 'Window'
                 submenu: templateWindow viewstate
             }
+        , {
+          label: "Help"
+          submenu: [
+            {
+              label: 'About'
+              click: () -> action 'show-about'
+            }
+          ]
+        }
     ].filter (n) -> n != undefined
 
 module.exports = (viewstate) ->

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -354,16 +354,10 @@ templateMenu = (viewstate) ->
         }, {
             label: 'Edit'
             submenu: templateEdit viewstate
-        },{
+        }, {
             label: 'View'
             submenu: templateView viewstate
-        }
-        if isDarwin
-            {
-                label: 'Window'
-                submenu: templateWindow viewstate
-            }
-        , {
+        }, {
           label: "Help"
           submenu: [
             {
@@ -372,6 +366,12 @@ templateMenu = (viewstate) ->
             }
           ]
         }
+        if isDarwin
+            {
+                label: 'Window'
+                submenu: templateWindow viewstate
+            }
+
     ].filter (n) -> n != undefined
 
 module.exports = (viewstate) ->


### PR DESCRIPTION
Shows a menu entry and about window that has the following information:

It follows the same logic when building the layout as the main window
- Version number
- License
- Main authors
- Contributors
- Link to github.com/yakyak

Additionally if there is a newer version, then it is shown a message in this window

![image](https://cloud.githubusercontent.com/assets/211358/19648615/8c9cd82c-99fa-11e6-8bb1-d17df9dc2039.png)

version.coffee was changed to follow 4 spaces tab indentation and added an noAlert argument, which checks for newer versions, but without showing an alert.

_note:_ to prevent lingering processes, both the main and about window are explicitly destroyed.
