### PR TITLE
fallback to initials when thumbnail image not available

### DIFF
--- a/src/ui/css/yakyak/convadd.less
+++ b/src/ui/css/yakyak/convadd.less
@@ -1,4 +1,15 @@
 .convadd {
+  .initials {
+      border-radius: 50%;
+      width: 50px;
+      height: 50px;
+      text-align: center;
+      font-size: 17px;
+      line-height: 50px;
+      color: var(--white);
+      background: var(--grey);
+      text-transform: uppercase;
+  }
   padding: 20px 20px 0;
   h1{
     margin-top: 30px;

--- a/src/ui/css/yakyak/convlist.less
+++ b/src/ui/css/yakyak/convlist.less
@@ -1,4 +1,3 @@
-
 .convlist {
     .label {
         font-size: 9px;

--- a/src/ui/css/yakyak/messages.less
+++ b/src/ui/css/yakyak/messages.less
@@ -14,6 +14,14 @@
         text-align: center;
         color: var(--darkgrey);
     }
+    &.fallback-on .ugroup .sender {
+        img {
+            display: none;
+        }
+        .initials.fallback {
+            display:inherit;
+        }
+    }
     .ugroup {
         margin-top: 17px;
         position: relative;
@@ -41,6 +49,9 @@
                 display: flex;
                 justify-content: center;
                 align-items: center;
+                &.fallback {
+                    display:none;
+                }
             }
             span {
                 margin-left: 45px;

--- a/src/ui/css/yakyak/messages.less
+++ b/src/ui/css/yakyak/messages.less
@@ -14,14 +14,6 @@
         text-align: center;
         color: var(--darkgrey);
     }
-    &.fallback-on .ugroup .sender {
-        img {
-            display: none;
-        }
-        .initials.fallback {
-            display:inherit;
-        }
-    }
     .ugroup {
         margin-top: 17px;
         position: relative;
@@ -52,6 +44,12 @@
                 &.fallback {
                     display:none;
                 }
+            }
+            img.fallback-on {
+                display: none;
+            }
+            .initials.fallback.fallback-on {
+                display: inherit;
             }
             span {
                 margin-left: 45px;

--- a/src/ui/views/convadd.coffee
+++ b/src/ui/views/convadd.coffee
@@ -1,5 +1,5 @@
 
-{throttle, nameof, fixlink} = require '../util'
+{initialsof, throttle, nameof, fixlink} = require '../util'
 chilledaction = throttle 1500, action
 
 unique = (obj) -> obj.id.chat_id or obj.id.gaia_id
@@ -82,10 +82,10 @@ module.exports = view (models) ->
               li class: 'selected', ->
                   if purl = r.properties?.photo_url ? entity[cid]?.photo_url
                     purl += "?sz=50" unless viewstate?.showAnimatedThumbs
-                    img src:fixlink(purl)
+                    img src:fixlink(purl), onerror: ->
+                        this.outerHTML = drawInitials(entity, cid)
                   else
-                      img src:"images/photo.jpg"
-                      entity.needEntity cid
+                      drawInitials(entity, cid)
                   p nameof r.properties
               , onclick:(e) -> if not editing then action 'deselectentity', r
 
@@ -97,10 +97,12 @@ module.exports = view (models) ->
               li ->
                   if purl = r.properties?.photo_url ? entity[cid]?.photo_url
                     purl += "?sz=50" unless viewstate?.showAnimatedThumbs
-                    img src:fixlink(purl)
+                    img src:fixlink(purl), onerror: ->
+                        this.outerHTML = drawInitials(entity, cid)
                   else
-                      img src:"images/photo.jpg"
-                      entity.needEntity cid
+                      # in case the image is not available, it
+                      #  fallbacks to initials
+                      drawInitials(entity, cid)
                   p r.properties.display_name
               , onclick:(e) -> action 'selectentity', r
 
@@ -126,5 +128,10 @@ module.exports = view (models) ->
             span "OK"
 
       mayRestoreInitialValues models
+
+drawInitials = (entity, cid) ->
+    entity.needEntity(cid)
+    initials = initialsof entity[cid]
+    div class:'initials', initials
 
 onclickaction = (a) -> (ev) -> action a

--- a/src/ui/views/convlist.coffee
+++ b/src/ui/views/convlist.coffee
@@ -34,7 +34,11 @@ module.exports = view (models) ->
                                 image += "?sz=50"
                             if image
                                 img src:fixlink(image), onerror: ->
-                                    this.src = fixlink("images/photo.jpg")
+                                    # in case the image is not available, it
+                                    #  fallbacks to initials
+                                    entity.needEntity(p.id)
+                                    initials = initialsof entity[p.id]
+                                    this.outerHTML = div class:'initials', initials
                             else
                                 entity.needEntity(p.id)
                                 initials = initialsof entity[p.id]

--- a/src/ui/views/convlist.coffee
+++ b/src/ui/views/convlist.coffee
@@ -30,19 +30,27 @@ module.exports = view (models) ->
                         for p, index in ents
                             break if index >= 4
                             image = p.photo_url
+                            # write initials as data-initials in img elements
+                            entity.needEntity(p.id)
+                            initials = initialsof entity[p.id]
                             if image and !viewstate.showAnimatedThumbs
                                 image += "?sz=50"
                             if image
-                                img src:fixlink(image), onerror: ->
+                                img src:fixlink(image)
+                                , "data-initials": initials
+                                , "data-id": p.id
+                                , onerror: ->
                                     # in case the image is not available, it
                                     #  fallbacks to initials
-                                    entity.needEntity(p.id)
-                                    initials = initialsof entity[p.id]
-                                    this.outerHTML = div class:'initials', initials
+                                    this.outerHTML = div class:'initials'
+                                    , "data-initials": this.dataset.initials
+                                    , "data-id": this.dataset.id
+                                    , this.dataset.initials
                             else
-                                entity.needEntity(p.id)
-                                initials = initialsof entity[p.id]
-                                div class:'initials', initials
+                                div class: 'initials'
+                                , "data-id": p.id
+                                , "data-initials": initials
+                                , initials
 
                         if ents.length>4
                             div class:'moreuser', ents.length

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -159,9 +159,12 @@ drawAvatar = (u, sender, viewstate, entity) ->
             img src:fixlink(purl), "data-id": u.cid, "data-initials": initials,  onerror: ->
                 # in case the image is not available, it
                 #  fallbacks to initials
-                document.querySelector('.messages').classList.add "fallback-on"
+                document.querySelectorAll('*[data-id="' + this.dataset.id + '"]').forEach (el) ->
+                    el.classList.add "fallback-on"
             , onload: ->
-                document.querySelector('.messages').classList.remove "fallback-on"
+                # when loading successfuly, update again all other imgs
+                document.querySelectorAll('*[data-id="' + this.dataset.id + '"]').forEach (el) ->
+                    el.classList.remove "fallback-on"
             div class:'initials fallback', "data-id": u.cid, initials
         else
             div class:'initials', initials

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -156,7 +156,13 @@ drawAvatar = (u, sender, viewstate, entity) ->
         if purl and !viewstate?.showAnimatedThumbs
             purl += "?sz=50"
         if purl
-            img src:fixlink(purl)
+            img src:fixlink(purl), "data-id": u.cid, "data-initials": initials,  onerror: ->
+                # in case the image is not available, it
+                #  fallbacks to initials
+                document.querySelector('.messages').classList.add "fallback-on"
+            , onload: ->
+                document.querySelector('.messages').classList.remove "fallback-on"
+            div class:'initials fallback', "data-id": u.cid, initials
         else
             div class:'initials', initials
 


### PR DESCRIPTION
It was reported in issue #196 that some user's avatar do not show up with an error on the console log.

These were replaced by a generic image. **This fix uses the user's initials instead.**

This problem seem to only affect contacts that have a "private" avatar, that requires a login in google's infrastructure to get.
### TODO:
- [x] Messages show either all initials or all images
  - Problem is that when using the same logic as contact list / conversation add there is a bigger bug
- [x] Group chats have repetitive initials 
- [x] Details of the chat show default image
- [ ] Avatar has a lag changing when switching between conversations that have a valid avatar and problematic one
