### PR TITLE
[NEED HELP] Shows who has seen each message group

### DIFF
--- a/src/ui/css/yakyak/messages.less
+++ b/src/ui/css/yakyak/messages.less
@@ -19,6 +19,31 @@
         position: relative;
         width: 66%;
         margin-left: 25px;
+        .seen {
+          text-decoration: none;
+          font-size: 11px;
+          color: var(--darkgrey);
+          display: inline-block;
+          margin-right: 25px;
+          img, .initials {
+              object-fit: cover;
+              border-radius: 50%;
+              width: 25px;
+              height: 25px;
+              border: 5px solid var(--lightgrey);
+              color: var(--white);
+              background: var(--grey);
+              position: absolute;
+              bottom: 0px;
+              text-align: center;
+              font-size: 10px;
+              line-height: 41px;
+              text-transform: uppercase;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+          }
+        }
         .sender {
             text-decoration: none;
             font-size: 11px;

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -114,7 +114,7 @@ handle 'toggleshowtray', ->
     viewstate.setShowTray(not viewstate.showtray)
 
 handle 'toggleshowseenstatus', ->
-    viewstate.setShowSeenStatus(not viewstate.showSeenStatus)
+    viewstate.setShowSeenStatus(not viewstate.showseenstatus)
 
 handle 'togglemenu', ->
     mainWindow = remote.getCurrentWindow()

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -113,6 +113,9 @@ handle 'sendmessage', (txt = '') ->
 handle 'toggleshowtray', ->
     viewstate.setShowTray(not viewstate.showtray)
 
+handle 'toggleshowseenstatus', ->
+    viewstate.setShowSeenStatus(not viewstate.showSeenStatus)
+
 handle 'togglemenu', ->
     mainWindow = remote.getCurrentWindow()
     if mainWindow.isMenuBarVisible() then mainWindow.setMenuBarVisibility(false) else mainWindow.setMenuBarVisibility(true)

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -34,7 +34,7 @@ module.exports = exp = {
     startminimizedtotray: tryparse(localStorage.startminimizedtotray) or false
     closetotray: tryparse(localStorage.closetotray) or false
     showDockOnce: true
-    showSeenStatus: tryparse(localStorage.showseenstatus) or false
+    showseenstatus: tryparse(localStorage.showseenstatus) or false
 
     setState: (state) ->
         return if @state == state
@@ -116,7 +116,7 @@ module.exports = exp = {
         updated 'viewstate'
 
     setShowSeenStatus: (val) ->
-        @showSeenStatus = val
+        @showseenstatus = val
         updated 'viewstate'
 
     setLastKeyDown: do ->

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -116,7 +116,7 @@ module.exports = exp = {
         updated 'viewstate'
 
     setShowSeenStatus: (val) ->
-        @showseenstatus = localStorage.showseenstatus = !!value
+        @showseenstatus = localStorage.showseenstatus = !!val
         updated 'viewstate'
 
     setLastKeyDown: do ->

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -34,6 +34,7 @@ module.exports = exp = {
     startminimizedtotray: tryparse(localStorage.startminimizedtotray) or false
     closetotray: tryparse(localStorage.closetotray) or false
     showDockOnce: true
+    showSeenStatus: tryparse(localStorage.showseenstatus) or false
 
     setState: (state) ->
         return if @state == state
@@ -114,6 +115,10 @@ module.exports = exp = {
         @loggedin = val
         updated 'viewstate'
 
+    setShowSeenStatus: (val) ->
+        @showSeenStatus = val
+        updated 'viewstate'
+
     setLastKeyDown: do ->
         {TYPING, PAUSED, STOPPED} = Client.TypingStatus
         lastEmitted = 0
@@ -138,7 +143,7 @@ module.exports = exp = {
                         action 'settyping', STOPPED
                     , 6000
                 , 6000
-    
+
     setShowConvMin: (doshow) ->
         return if @showConvMin == doshow
         @showConvMin = localStorage.showConvMin = doshow

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -116,7 +116,7 @@ module.exports = exp = {
         updated 'viewstate'
 
     setShowSeenStatus: (val) ->
-        @showseenstatus = val
+        @showseenstatus = localStorage.showseenstatus = !!value
         updated 'viewstate'
 
     setLastKeyDown: do ->

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -328,7 +328,7 @@ templateView = (viewstate) ->
                     label: 'Show seen status in messages'
                     type: 'checkbox'
                     enabled: viewstate.loggedin
-                    checked: viewstate.showSeenStatus
+                    checked: viewstate.showseenstatus
                     click: -> action 'toggleshowseenstatus'
                 }
             ]

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -321,6 +321,18 @@ templateView = (viewstate) ->
                 checked:  viewstate.hidedockicon
                 click: -> action 'togglehidedockicon'
             }
+        , {
+            label: 'Experimental'
+            submenu: [
+                {
+                    label: 'Show seen status in messages'
+                    type: 'checkbox'
+                    enabled: viewstate.loggedin
+                    checked: viewstate.showSeenStatus
+                    click: -> action 'toggleshowseenstatus'
+                }
+            ]
+        }
     ].filter (n) -> n != undefined
 
 templateWindow = (viewstate) -> [

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -121,25 +121,26 @@ module.exports = view (models) ->
                         div class:clz.join(' '), ->
                             drawAvatar u, sender, viewstate, entity
                             if entity.isSelf(u.cid)
-                                drawSeenElement(c, u, entity, g)
+                                drawSeenElement(c, u, entity, events)
                             div class:'umessages', ->
                                 drawMessage(e, entity) for e in events
                             , onDOMSubtreeModified: (e) ->
                                 window.twemoji?.parse e.target if process.platform == 'win32'
                             unless entity.isSelf(u.cid)
-                                drawSeenElement(c, u, entity, g)
+                                drawSeenElement(c, u, entity, events)
 
     if lastConv != conv_id
         lastConv = conv_id
         later atTopIfSmall
 
-drawSeenElement = (c, u, entity, g) ->
+drawSeenElement = (c, u, entity, events) ->
     temp_set = new Set()
     for contacts in c.read_state
         other = contacts.participant_id.chat_id
         if other != u.cid &&
            !entity.isSelf(other) &&
-           contacts.latest_read_timestamp >= g.end
+           # only add "seen" avatar if last message from group is seen
+           contacts.latest_read_timestamp >= events[events.length - 1].timestamp
             if !temp_set.has(entity[other].id)
                 temp_set.add entity[other].id
                 drawSeenAvatar entity[other]

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -121,7 +121,7 @@ module.exports = view (models) ->
                         div class:clz.join(' '), ->
                             drawAvatar u, sender, viewstate, entity
                             if entity.isSelf(u.cid)
-                                drawSeenElement(c, u, entity, events)
+                                drawSeenElement(c, u, entity, events, viewstate)
                             div class:'umessages', ->
                                 drawMessage(e, entity) for e in events
                             , onDOMSubtreeModified: (e) ->
@@ -133,17 +133,18 @@ module.exports = view (models) ->
         lastConv = conv_id
         later atTopIfSmall
 
-drawSeenElement = (c, u, entity, events) ->
-    temp_set = new Set()
-    for contacts in c.read_state
-        other = contacts.participant_id.chat_id
-        if other != u.cid &&
-           !entity.isSelf(other) &&
-           # only add "seen" avatar if last message from group is seen
-           contacts.latest_read_timestamp >= events[events.length - 1].timestamp
-            if !temp_set.has(entity[other].id)
-                temp_set.add entity[other].id
-                drawSeenAvatar entity[other]
+drawSeenElement = (c, u, entity, events, viewstate) ->
+    if viewstate?.showSeenStatus
+        temp_set = new Set()
+        for contacts in c.read_state
+            other = contacts.participant_id.chat_id
+            if other != u.cid &&
+               !entity.isSelf(other) &&
+               # only add "seen" avatar if last message from group is seen
+               contacts.latest_read_timestamp >= events[events.length - 1].timestamp
+                if !temp_set.has(entity[other].id)
+                    temp_set.add entity[other].id
+                    drawSeenAvatar entity[other]
 
 groupEventsByMessageType = (event) ->
     res = []
@@ -166,7 +167,10 @@ isMeMessage = (e) ->
 
 drawSeenAvatar = (u) ->
     initials = initialsof u
-    span class: "seen", style: "", "data-id": u.id, title: u.display_name, ->
+    span class: "seen"
+    , "data-id": u.id
+    , title: u.display_name
+    , ->
         purl = u?.photo_url
         if purl and !viewstate?.showAnimatedThumbs
             purl += "?sz=25"
@@ -174,7 +178,6 @@ drawSeenAvatar = (u) ->
             img src:fixlink(purl)
         else
             div class:'initials', initials
-
 
 drawAvatar = (u, sender, viewstate, entity) ->
     initials = initialsof entity[u.cid]

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -134,7 +134,7 @@ module.exports = view (models) ->
         later atTopIfSmall
 
 drawSeenElement = (c, u, entity, events, viewstate) ->
-    if viewstate?.showSeenStatus
+    if viewstate?.showseenstatus
         temp_set = new Set()
         for contacts in c.read_state
             other = contacts.participant_id.chat_id


### PR DESCRIPTION
This is a big feature that was missing from YakYak and is implemented and working.. kinda of
### TODO:
- [ ] only works after the other party in the conversation has an action**, i.e. sends a message. (more details below)
- [x] Avatar of most recent message groups (not all though) disappear
- [ ] Decide on showing "seen" on each message group in conversation, or just the latest one (like hangouts)

All items require help, but I guess the most important one is the first, problem described below:
### Biggest problem:

For some reason `latest_read_timestamp` is initialized at `0` when opening the conversation (regardless of the history).. **I need help figuring this out, on what to use to get this value well initialized.**

note: it adds a seen avatar to each message group if that is seen (this can be customizable via an option to show all, show only last)

it has some quirks that need to be solved, I'm seeing the avatar sometimes disappearing and wiu

![image](https://cloud.githubusercontent.com/assets/211358/19780237/2d74bb74-9c7c-11e6-889a-ef1e9e85826d.png)
