### PR TITLE
2 fixes on new conversations and removal

### DIFF
--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -48,6 +48,8 @@ handle 'init', (init) ->
     require('./version').check()
 
 handle 'chat_message', (ev) ->
+    unless conv[ev.conversation_id]
+        ipc.send 'reqinit'
     conv.addChatMessage ev
     # these messages are to go through notifications
     notify.addToNotify ev
@@ -95,6 +97,7 @@ handle 'history', (conv_id, timestamp) ->
     ipc.send 'getconversation', conv_id, timestamp, 20
 
 handle 'handlehistory', (r) ->
+    console.log 'state history', r
     return unless r.conversation_state
     conv.updateHistory r.conversation_state
 
@@ -361,6 +364,7 @@ handle 'deleteconv', (confirmed) ->
             action 'deleteconv', true
     else
         ipc.send 'deleteconversation', conv_id
+        viewstate.selectConvIndex(0)
         viewstate.setState(viewstate.STATE_NORMAL)
 
 handle 'leaveconv', (confirmed) ->
@@ -370,6 +374,7 @@ handle 'leaveconv', (confirmed) ->
             action 'leaveconv', true
     else
         ipc.send 'removeuser', conv_id
+        viewstate.selectConvIndex(0)
         viewstate.setState(viewstate.STATE_NORMAL)
 
 handle 'lastkeydown', (time) -> viewstate.setLastKeyDown time

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -361,6 +361,7 @@ handle 'deleteconv', (confirmed) ->
             action 'deleteconv', true
     else
         ipc.send 'deleteconversation', conv_id
+        viewstate.setState(viewstate.STATE_NORMAL)
 
 handle 'leaveconv', (confirmed) ->
     conv_id = viewstate.selectedConv

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -48,8 +48,10 @@ handle 'init', (init) ->
     require('./version').check()
 
 handle 'chat_message', (ev) ->
-    unless conv[ev.conversation_id]
-        ipc.send 'reqinit'
+    # TODO entity is not fetched in usable time for first notification
+    # if does not have user on cache
+    entity.needEntity ev.sender_id.chat_id unless entity[ev.sender_id.chat_id]?
+    # add chat to conversation
     conv.addChatMessage ev
     # these messages are to go through notifications
     notify.addToNotify ev
@@ -97,7 +99,6 @@ handle 'history', (conv_id, timestamp) ->
     ipc.send 'getconversation', conv_id, timestamp, 20
 
 handle 'handlehistory', (r) ->
-    console.log 'state history', r
     return unless r.conversation_state
     conv.updateHistory r.conversation_state
 
@@ -408,7 +409,12 @@ handle 'handlerecentconversations', (r) ->
     connection.setEventState connection.IN_SYNC
 
 handle 'client_conversation', (c) ->
-    conv.add c unless conv[c?.conversation_id?.id]
+    # Conversation must be added, even if already exists
+    #  why? because when a new chat message for a new conversation appears
+    #  a skeleton is made of a conversation
+    # If there is a problem with this change, then we should only merge
+    #  when essential information is missing (ex. participant_data)
+    conv.add c
 
 handle 'hangout_event', (e) ->
     return unless e?.hangout_event?.event_type in ['START_HANGOUT', 'END_HANGOUT']

--- a/src/ui/views/convadd.coffee
+++ b/src/ui/views/convadd.coffee
@@ -108,7 +108,6 @@ module.exports = view (models) ->
 
       if editing
         div class:'leave', ->
-          console.log conversation
           if conversation?.type?.indexOf('ONE_TO_ONE') > 0
               div class:'button', title:'Delete conversation',
               onclick:onclickaction('deleteconv'), ->


### PR DESCRIPTION
### New conversations via new message received

- When new conversations appear, they have no avatar on the conversation list and impossible to open details

Handle to add *client_conversation* was already available, but it was a bit conservative (only adding when conversation did not exist)

When a conversation starts via a new message received a conv. skeleton is created thus rendering the handle useless

### Removal of conversation

after confirming that we want to remove, changes to top conversation

previous behavior kept interface to remove user (that was already removed)