### PR TITLE
"Loading contacts" text changed sizes and improvement on about

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -379,12 +379,17 @@ app.on 'ready', ->
           show: false
           parent: mainWindow
           resizable: false
+          frame: false
+          titleBarStyle: 'hidden'
         }
 
         aboutWindow.loadURL 'file://' + __dirname + '/ui/about.html'
         aboutWindow.once 'ready-to-show', () ->
             aboutWindow.setMenu(null)
             aboutWindow.show()
+
+            aboutWindow.on 'blur', ->
+                aboutWindow.close()
 
     ipc.on 'errorInWindow', (ev, error) ->
         console.log "Error on YakYak window:\n", error, "\n--- End of error message in YakYak window."

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -58,20 +58,20 @@
             align-items: center;
             div  {
                 text-align: center;
-                margin-bottom: 1em;
+                margin-bottom: 15px; // cannot be relative measures
                 img {
-                    height: 160px;
+                    height: 160px; // cannot be relative measures
                 }
                 span.text {
                     text-align: center;
-                    font-size: 2em;
+                    font-size: 30px; // cannot be relative measures
                     color: #555;
                 }
                 &.spinner {
                   text-align: center;
                   > div {
-                    width: 18px;
-                    height: 18px;
+                    width: 18px;   // cannot be relative measures
+                    height: 18px;  // cannot be relative measures
                     background-color: var(--green);
 
                     border-radius: 100%;

--- a/src/ui/css/yakyak/global.less
+++ b/src/ui/css/yakyak/global.less
@@ -106,3 +106,13 @@ img.emoji {
       display: inherit;
   }
 }
+
+.close-me {
+    font-size: .95em;
+    color: #777;
+    position:absolute;
+    top: 0;
+    right: 0;
+    cursor: pointer;
+}
+

--- a/src/ui/css/yakyak/input.less
+++ b/src/ui/css/yakyak/input.less
@@ -58,12 +58,6 @@
                 transform: perspective(1px) translateY(-50%);
             }
         }
-        .close-preview {
-            position:absolute;
-            top: 0;
-            right: 0;
-            cursor: pointer;
-        }
         img {
           max-height:22em;
         }

--- a/src/ui/views/aboutlayout.coffee
+++ b/src/ui/views/aboutlayout.coffee
@@ -24,6 +24,11 @@ localVersion = remote.require('electron').app.getVersion()
 module.exports = exp = layout ->
     div class: 'about', ->
         div ->
+            span onclick: (e) ->
+                window.close()
+            , ->
+                span class: 'close-me material-icons', ''
+        div ->
             img src: path.join __dirname, '..', '..', 'icons', 'icon@8.png'
         div class: 'name', ->
             h2 'YakYak v' + localVersion

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -38,7 +38,7 @@ openByDefault = 'people'
 module.exports = view (models) ->
     div class:'input', ->
         div id: 'preview-container', ->
-            div class: 'close-preview material-icons'
+            div class: 'close-me material-icons'
                 , onclick: (e) ->
                     element = document.getElementById 'preview-img'
                     element.src = ''


### PR DESCRIPTION
Former PR #472 did not fix the problem tracked in #471 completely

**Somehow the relative font-size changes after connecting in Mac OS X only.**

This is reaaaaaaaally strange, but was corrected by using absolute dimensions for font-size and margins.

-----

plus, changing the about window to a frameless one that closes when clicking on top right corner or outside the window