### PR TITLE
osx instead of darwin in package name

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -300,7 +300,10 @@ deploy = (platform, arch) ->
         else if appPaths?.length > 0
             json = JSON.parse(fs.readFileSync('./package.json'))
             zippath = "#{appPaths[0]}/"
-            fileprefix = "yakyak-#{json.version}-#{platform}-#{arch}"
+            if platform == 'darwin'
+                fileprefix = "yakyak-#{json.version}-osx"
+            else
+                fileprefix = "yakyak-#{json.version}-#{platform}-#{arch}"
 
             if platform == 'linux'
                 tarIt zippath, fileprefix, -> deferred.resolve()


### PR DESCRIPTION
This way generates yakyak-1.4.0-**osx**.zip  instead of yakyak-1.4.0-**darwin-x64**.zip

#482