### PR TITLE
Corrections on feature 'seen'

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -298,6 +298,10 @@ app.on 'ready', ->
     # no retries, dedupe on conv_id
     ipc.on 'setfocus', seqreq (ev, conv_id) ->
         client.setfocus conv_id
+        client.getconversation conv_id, new Date(), 1, true
+        .then (r) ->
+            ipcsend 'getconversationmetadata:response', r
+
     , false, (ev, conv_id) -> conv_id
 
     ipc.on 'appfocus', ->

--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -79,6 +79,10 @@ ipc.on 'createconversation:result', (ev, c, name) ->
 ipc.on 'syncallnewevents:response', (ev, r) -> action 'handlesyncedevents', r
 ipc.on 'syncrecentconversations:response', (ev, r) -> action 'handlerecentconversations', r
 ipc.on 'getconversation:response', (ev, r) -> action 'handlehistory', r
+#
+# gets metadata from conversation after setting focus
+ipc.on 'getconversationmetadata:response', (ev, r) ->
+    action 'handleconversationmetadata', r
 ipc.on 'uploadingimage', (ev, spec) -> action 'uploadingimage', spec
 ipc.on 'querypresence:result', (ev, r) -> action 'setpresence', r
 

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -196,6 +196,8 @@
             overflow-x: hidden;
             overflow-y: auto;
             padding-bottom: 35px;
+            display: flex;
+            flex-flow: column-reverse;
         }
         > .maininfo {
             flex: none;

--- a/src/ui/css/yakyak/applayout.less
+++ b/src/ui/css/yakyak/applayout.less
@@ -179,7 +179,7 @@
         > .list {
             flex: 1;
             overflow-x: hidden;
-            overflow-y: auto;
+            overflow-y: scroll;
         }
         > .lfoot {
             flex: none;
@@ -194,7 +194,7 @@
         > .main {
             flex: 1;
             overflow-x: hidden;
-            overflow-y: auto;
+            overflow-y: scroll;
             padding-bottom: 35px;
             display: flex;
             flex-flow: column-reverse;

--- a/src/ui/css/yakyak/messages.less
+++ b/src/ui/css/yakyak/messages.less
@@ -20,32 +20,35 @@
         width: 66%;
         margin-left: 25px;
         .seen {
-          text-decoration: none;
-          font-size: 11px;
-          color: var(--darkgrey);
-          margin-right: 25px;
-          display: inline-block;
-          &.show {
-              display: inline-block;
-          }
-          &.fallback-on img{
-              display: none;
-          }
-          &.fallback-on .initials.fallback {
-              display: inherit;
-          }
-          img, .initials {
-              width: 21px;
-              height: 21px;
-              border: 2px solid var(--lightgrey);
-              bottom: 0px;
-              font-size: 10px;
-              line-height: 41px;
-              display: flex;
-              &.fallback {
-                  display: none;
-              }
-          }
+            filter: saturate(40%);
+            text-decoration: none;
+            font-size: 11px;
+            color: var(--darkgrey);
+            margin-right: 25px;
+            display: inline-block;
+            &.show {
+               display: inline-block;
+            }
+            .avatar {
+                &.fallback-on img{
+                    display: none;
+                }
+                &.fallback-on .initials.fallback {
+                    display: flex;
+                }
+                img, .initials {
+                    width: 21px;
+                    height: 21px;
+                    border: 2px solid var(--lightgrey);
+                    bottom: 0px;
+                    font-size: 10px;
+                    line-height: 41px;
+                    display: flex;
+                    &.fallback {
+                        display: none;
+                    }
+                }
+            }
         }
         .sender {
             text-decoration: none;

--- a/src/ui/css/yakyak/messages.less
+++ b/src/ui/css/yakyak/messages.less
@@ -20,7 +20,7 @@
         width: 66%;
         margin-left: 25px;
         .seen {
-            filter: saturate(40%);
+            filter: saturate(60%);
             text-decoration: none;
             font-size: 11px;
             color: var(--darkgrey);
@@ -47,6 +47,7 @@
                     &.fallback {
                         display: none;
                     }
+                    opacity: 0.5;
                 }
             }
         }

--- a/src/ui/css/yakyak/messages.less
+++ b/src/ui/css/yakyak/messages.less
@@ -24,7 +24,7 @@
           font-size: 11px;
           color: var(--darkgrey);
           margin-right: 25px;
-          display: none;
+          display: inline-block;
           &.show {
               display: inline-block;
           }

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -98,6 +98,12 @@ handle 'attop', (attop) ->
 handle 'history', (conv_id, timestamp) ->
     ipc.send 'getconversation', conv_id, timestamp, 20
 
+handle 'handleconversationmetadata', (r) ->
+    return unless r.conversation_state
+    # removing events so they don't get merged
+    r.conversation_state.event = null
+    conv.updateMetadata r.conversation_state
+
 handle 'handlehistory', (r) ->
     return unless r.conversation_state
     conv.updateHistory r.conversation_state

--- a/src/ui/models/conv.coffee
+++ b/src/ui/models/conv.coffee
@@ -310,16 +310,15 @@ funcs =
             later -> action 'history', conv_id, timestamp, HISTORY_AMOUNT
             updated 'conv'
 
-    updateHistory: (state) ->
+    updateMetadata: (state, redraw = true) ->
         conv_id = state?.conversation_id?.id
         return unless c = lookup[conv_id]
-        c.requestinghistory = false
-        event = state?.event
 
         c.read_state = state.conversation?.read_state ? c.read_state
-        c.event = (event ? []).concat (c.event ? [])
-        c.nomorehistory = true if event?.length == 0
 
+        @redraw_conversation() if redraw
+
+    redraw_conversation: () ->
         # first signal is to give views a change to record the
         # current view position before injecting new DOM
         updated 'beforeHistory'
@@ -328,6 +327,19 @@ funcs =
         # last signal is to move view to be at same place
         # as when we injected DOM.
         updated 'afterHistory'
+
+    updateHistory: (state) ->
+        conv_id = state?.conversation_id?.id
+        return unless c = lookup[conv_id]
+        c.requestinghistory = false
+        event = state?.event
+
+        @updateMetadata(state, false)
+
+        c.event = (event ? []).concat (c.event ? [])
+        c.nomorehistory = true if event?.length == 0
+
+        @redraw_conversation()
 
     updatePlaceholderImage: ({conv_id, client_generated_id, path}) ->
         return unless c = lookup[conv_id]

--- a/src/ui/views/applayout.coffee
+++ b/src/ui/views/applayout.coffee
@@ -144,11 +144,8 @@ do ->
     exp.recordMainPos = ->
         el = lastVisibleMessage()
         id = el?.id
-        console.log 'id', id
-        console.log 'el', document.getElementById id
         return unless el and id
         ofs = topof el
-        console.log 'ofs', ofs
 
     exp.adjustMainPos = ->
         return unless id and ofs

--- a/src/ui/views/applayout.coffee
+++ b/src/ui/views/applayout.coffee
@@ -144,8 +144,11 @@ do ->
     exp.recordMainPos = ->
         el = lastVisibleMessage()
         id = el?.id
+        console.log 'id', id
+        console.log 'el', document.getElementById id
         return unless el and id
         ofs = topof el
+        console.log 'ofs', ofs
 
     exp.adjustMainPos = ->
         return unless id and ofs

--- a/src/ui/views/convlist.coffee
+++ b/src/ui/views/convlist.coffee
@@ -77,7 +77,7 @@ drawMessage = (e, entity) ->
     mclz = ['message']
     mclz.push c for c in MESSAGE_CLASSES when e[c]?
     title = if e.timestamp then moment(e.timestamp / 1000).calendar() else null
-    div id:e.event_id, key:e.event_id, class:mclz.join(' '), title:title, ->
+    div id:"list_#{e.event_id}", key:"list_#{e.event_id}", class:mclz.join(' '), title:title, ->
         if e.chat_message
             content = e.chat_message?.message_content
             format content

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -207,7 +207,6 @@ drawMessage = (e, entity) ->
     mclz.push c for c in MESSAGE_CLASSES when e[c]?
     title = if e.timestamp then moment(e.timestamp / 1000).calendar() else null
     div id:e.event_id, key:e.event_id, class:mclz.join(' '), title:title, ->
-        span "#{e.event_id}:"
         if e.chat_message
             content = e.chat_message?.message_content
             format content

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -139,8 +139,11 @@ module.exports = view (models) ->
             all_seen = document
             .querySelectorAll(".seen[data-id='#{participant.chat_id}']")
             # select last one
-            if all_seen.length > 0
-                all_seen[all_seen.length - 1].classList.add 'show'
+            #  NOT WORKING
+            #if all_seen.length > 0
+            #    all_seen.forEach (el) ->
+            #        el.classList.remove 'show'
+            #    all_seen[all_seen.length - 1].classList.add 'show'
     if lastConv != conv_id
         lastConv = conv_id
         later atTopIfSmall

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -207,6 +207,7 @@ drawMessage = (e, entity) ->
     mclz.push c for c in MESSAGE_CLASSES when e[c]?
     title = if e.timestamp then moment(e.timestamp / 1000).calendar() else null
     div id:e.event_id, key:e.event_id, class:mclz.join(' '), title:title, ->
+        span "#{e.event_id}:"
         if e.chat_message
             content = e.chat_message?.message_content
             format content


### PR DESCRIPTION
### Correction from new feature

**Bug:** Show only last seen avatar is not working properly once you start to scroll up and history is fetched. Duplicate avatars are shown and sometimes the last one is not shown.

**Solution:** Show all seen avatars throughout the conversation

Also makes feature more robust, everytime the conversation gets focus it also requests an update on the metadata and updates it, instead of relying on getting it from history

### General correction in YakYak

**Bug:** I've been noticing through my usage of YakYak that sometimes YakYak starts scrolling up alone without input.

I found out why today why while implementing a more predicted way of getting the read_state: **We are using duplicate ids in the interface.**

 The message id is used in message pane, but also in the conversation list on the left. And this id is important as it is used when redrawing the conversation (to refresh it and get back at the same point). 

**Solution:** Message snippet id now has a prefix