### PR TITLE
use runSequence to compile perfore starting to deploy

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -17,6 +17,8 @@ filter     = require 'gulp-filter'
 Q          = require 'q'
 Stream     = require 'stream'
 spawn      = require('child_process').spawn
+# running tasks in sequence
+runSequence = require('run-sequence')
 
 #
 #
@@ -201,7 +203,8 @@ buildDeployTask = (platform, arch) ->
     gulp.task tasknameNoDep, ()->
         deploy platform, arch
     # set task with dependencies
-    gulp.task taskname, ['default'].concat tasknameNoDep
+    gulp.task taskname, (cb) ->
+      runSequence 'default', tasknameNoDep, cb
     #
     tasknameNoDep
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "gulp-zip": "^3.2.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.4.2",
+    "run-sequence": "^1.2.2",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0"
   }


### PR DESCRIPTION
calling on `npm run deploy:linux-x64` without compiling first would create a broken binary

using runSequence allows to run sequentially and allow for the default target to finish before starting to package.

thanks to @nerijus for picking this up :)

ps. @davibe I'm going to merge this now