### PR TITLE
Add wine warning when building windows binaries

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -315,7 +315,8 @@ deploy = (platform, arch) ->
             if ev?
                 console.log ' IMPORTANT for building Windows binaries outside Windows'
                 console.log ''
-                console.log ' It is required to have wine installed and configured. If problem persist try a different wine prefix.'
+                console.log ' It is required to have wine installed and configured.'
+                console.log ' If problem persist try a different wine prefix.
                 console.log ' -------------------------------------------------------'
 
                 console.log ''

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -311,6 +311,13 @@ deploy = (platform, arch) ->
         console.log ' Notice for building Windows binaries outside Windows'
         console.log ''
         console.log ' It is required to have wine32 installed and configured.'
+        console.log ''
+        console.log ' When building for a specific platform use:'
+        console.log ''
+        console.log ' $ npm run gulp deploy:<platform>-<architecture>'
+        console.log ''
+        console.log '       <platforms>: win32 | linux | darwin'
+        console.log '   <architectures>:  x64  | ia32'
         console.log '--------------------------------------------------------'
     #
     # actual packaging

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -315,7 +315,7 @@ deploy = (platform, arch) ->
             if ev?
                 console.log ' IMPORTANT for building Windows binaries outside Windows'
                 console.log ''
-                console.log ' It is required to have wine32 installed and configured.'
+                console.log ' It is required to have wine installed and configured. If problem persist try a different wine prefix.'
                 console.log ' -------------------------------------------------------'
 
                 console.log ''
@@ -328,8 +328,7 @@ deploy = (platform, arch) ->
                 console.log '   <architectures>:  x64  | ia32'
             else
                 console.log 'Notice: If there are problems with rcedit.exe,'
-                console.log ' please be sure to have wine 32bits installed'
-                console.log ' and configured.'
+                console.log ' please be sure to have wine installed and configured.'
             console.log '--------------------------------------------------------'
     #
     # actual packaging

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -316,7 +316,7 @@ deploy = (platform, arch) ->
                 console.log ' IMPORTANT for building Windows binaries outside Windows'
                 console.log ''
                 console.log ' It is required to have wine installed and configured.'
-                console.log ' If problem persist try a different wine prefix.
+                console.log ' If problem persists try a different wine prefix.'
                 console.log ' -------------------------------------------------------'
 
                 console.log ''

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -17,6 +17,7 @@ filter     = require 'gulp-filter'
 Q          = require 'q'
 Stream     = require 'stream'
 spawn      = require('child_process').spawn
+exec       = require('child_process').exec
 # running tasks in sequence
 runSequence = require('run-sequence')
 
@@ -306,19 +307,30 @@ deploy = (platform, arch) ->
     #
     # warning to users outside of windows of the dependency of wine32
     if platform == 'win32' && process.platform != 'win32'
-        console.log ''
-        console.log ''
-        console.log ' Notice for building Windows binaries outside Windows'
-        console.log ''
-        console.log ' It is required to have wine32 installed and configured.'
-        console.log ''
-        console.log ' When building for a specific platform use:'
-        console.log ''
-        console.log ' $ npm run gulp deploy:<platform>-<architecture>'
-        console.log ''
-        console.log '       <platforms>: win32 | linux | darwin'
-        console.log '   <architectures>:  x64  | ia32'
-        console.log '--------------------------------------------------------'
+        # test if wine is installed
+        child = exec 'wine --version'
+        , (ev)->
+            # if wine --version gives a bad error
+            console.log ''
+            if ev?
+                console.log ' IMPORTANT for building Windows binaries outside Windows'
+                console.log ''
+                console.log ' It is required to have wine32 installed and configured.'
+                console.log ' -------------------------------------------------------'
+
+                console.log ''
+                console.log ''
+                console.log ' When building for a specific platform use:'
+                console.log ''
+                console.log ' $ npm run gulp deploy:<platform>-<architecture>'
+                console.log ''
+                console.log '       <platforms>: win32 | linux | darwin'
+                console.log '   <architectures>:  x64  | ia32'
+            else
+                console.log 'Notice: If there are problems with rcedit.exe,'
+                console.log ' please be sure to have wine 32bits installed'
+                console.log ' and configured.'
+            console.log '--------------------------------------------------------'
     #
     # actual packaging
     packager packOpts, (err, appPaths) ->

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -300,8 +300,20 @@ deploy = (platform, arch) ->
     #
     # package the app and create a zip
     packOpts = opts
+    #
     if platform == 'darwin'
         packOpts.name = 'YakYak'
+    #
+    # warning to users outside of windows of the dependency of wine32
+    if platform == 'win32' && process.platform != 'win32'
+        console.log ''
+        console.log ''
+        console.log ' Notice for building Windows binaries outside Windows'
+        console.log ''
+        console.log ' It is required to have wine32 installed and configured.'
+        console.log '--------------------------------------------------------'
+    #
+    # actual packaging
     packager packOpts, (err, appPaths) ->
         if err?
             console.log ('Error: ' + err) if err?


### PR DESCRIPTION
When building in Linux and Mac OS X it checks if it has wine installed and print a warning to install

If wine is installed it gives a notice

![image](https://cloud.githubusercontent.com/assets/211358/21018129/a72417c8-bd63-11e6-8da0-96b000e45acb.png)
