### PR TITLE
remove "use strict" as it is not necessary

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -291,7 +291,6 @@ deploy = (platform, arch) ->
     #
     # necessary to add a callback to pipe (which is used to signal end of task)
     gulpCallback = (obj) ->
-        "use strict"
         stream = new Stream.Transform({objectMode: true})
         stream._transform = (file, unused, callback) ->
             obj()


### PR DESCRIPTION
obviously not necessary