### PR TITLE
nodejs version bump and show error window on pre-startup error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "6"
 notifications:
   email: false

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -428,6 +428,8 @@ app.on 'ready', ->
                 aboutWindow.close()
 
     ipc.on 'errorInWindow', (ev, error, winName = 'YakYak') ->
+        mainWindow.show() unless global.isReadyToShow
+        ipcsend 'expcetioninmain', error
         console.log "Error on #{winName} window:\n", error, "\n--- End of error message in #{winName} window."
 
     # propagate these events to the renderer

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -9,10 +9,10 @@
         #main-error {
             width: 90%;
             margin: auto;
-            padding-top: 30px;
+            padding-top: 3em;
         }
         #main-error p {
-            padding-top: 16px;
+            padding-top: 1em;
             padding-left: 110px;
         }
         #main-error h1 {
@@ -31,7 +31,7 @@
     <div id="main-error">
       <h1>An error has occured</h1>
       <div>
-        <p>If you are seeing this then probably an error has occured.</p>
+        <p>If you are seeing this then an error has occured with YakYak.</p>
         <p>To see what happened, <a href="javascript:void 0;" onclick="require('electron').remote.getCurrentWindow().webContents.openDevTools()">open the Inspector</a> and check if there is an error.</p>
         <p>Find if someone else is experiencing this by visiting
           <script>
@@ -40,9 +40,11 @@
             }
           </script>
           <a href="javascript:void 0;" onclick="openIssues()">
-            github.com/yakyak/yakyak/issues
+            our issue tracker
         </a> or create a new issue if you are the first <i>(please include a screenshot of the Inspector)</i>
         </p>
+        <p>Sorry for this.</p>
+        <p><i>&nbsp; YakYak team and community</i></p>
       </div>
     </div>
   </body>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -4,8 +4,46 @@
     <meta charset="utf-8">
     <title>YakYak</title>
     <link rel="stylesheet" href="app.css">
+    <style TYPE="text/css">
+    <!--
+        #main-error {
+            width: 90%;
+            margin: auto;
+            padding-top: 30px;
+        }
+        #main-error p {
+            padding-top: 16px;
+            padding-left: 110px;
+        }
+        #main-error h1 {
+            margin-bottom: 0px;
+            padding-left: 110px;
+            background-image: url(../icons/icon@16.png);
+            background-repeat: no-repeat;
+            background-size: 84px;
+            line-height: 84px;
+        }
+    -->
+    </style>
   </head>
   <body>
     <script src="app.js"></script>
+    <div id="main-error">
+      <h1>An error has occured</h1>
+      <div>
+        <p>If you are seeing this then probably an error has occured.</p>
+        <p>To see what happened, <a href="javascript:void 0;" onclick="require('electron').remote.getCurrentWindow().webContents.openDevTools()">open the Inspector</a> and check if there is an error.</p>
+        <p>Find if someone else is experiencing this by visiting
+          <script>
+            openIssues = function() {
+                require('electron').shell.openExternal("https://github.com/yakyak/yakyak/issues");
+            }
+          </script>
+          <a href="javascript:void 0;" onclick="openIssues()">
+            github.com/yakyak/yakyak/issues
+        </a> or create a new issue if you are the first <i>(please include a screenshot of the Inspector)</i>
+        </p>
+      </div>
+    </div>
   </body>
 </html>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -53,7 +53,7 @@
               </script>
               <a href="javascript:void 0;" onclick="openIssues()">
                 our issue tracker
-            </a> and join the discussion, or create a new one if you are the first. <i class="small">(please include a screenshot of the console tab in the Inspector)</i>
+            </a> and join the discussion, or create a new one if you are the first <i class="small">(please include a screenshot of the console tab in the Inspector)</i>.
             </p>
             <p>Sorry for this.</p>
             <p><i>&nbsp; YakYak team and community</i></p>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -15,9 +15,19 @@
             margin: auto;
             padding-top: 3em;
         }
-        #main-error p {
+        #main-error p,
+        #main-error h3 {
             padding-top: 1em;
             padding-left: 110px;
+        }
+        #main-error h1,
+        #main-error h3 {
+            font-weight: 100;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+        }
+        #main-error .small {
+            font-size: .9em;
         }
         #main-error h1 {
             margin-bottom: 0px;
@@ -34,7 +44,8 @@
           <div>
             <p>If you are seeing this then an error has occured with YakYak.</p>
             <p>To see what happened, <a href="javascript:void 0;" onclick="require('electron').remote.getCurrentWindow().webContents.openDevTools()">open the Inspector</a> and check the messages in the console tab.</p>
-            <p>Find if someone else is experiencing this by visiting
+            <h3>How to report</h3>
+            <p>Find if this error has already been reported at
               <script>
                 openIssues = function() {
                     require('electron').shell.openExternal("https://github.com/yakyak/yakyak/issues");
@@ -42,7 +53,7 @@
               </script>
               <a href="javascript:void 0;" onclick="openIssues()">
                 our issue tracker
-            </a> or create a new one if you are the first <i>(please include a screenshot of the console tab in the Inspector)</i>
+            </a> and join the discussion, or create a new one if you are the first. <i class="small">(please include a screenshot of the console tab in the Inspector)</i>
             </p>
             <p>Sorry for this.</p>
             <p><i>&nbsp; YakYak team and community</i></p>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -4,8 +4,12 @@
     <meta charset="utf-8">
     <title>YakYak</title>
     <link rel="stylesheet" href="app.css">
-    <style TYPE="text/css">
-    <!--
+  </head>
+  <body>
+    <script src="app.js"></script>
+    <div>
+        <style TYPE="text/css">
+        <!--
         #main-error {
             width: 90%;
             margin: auto;
@@ -23,29 +27,27 @@
             background-size: 84px;
             line-height: 84px;
         }
-    -->
-    </style>
-  </head>
-  <body>
-    <script src="app.js"></script>
-    <div id="main-error">
-      <h1>An error has occured</h1>
-      <div>
-        <p>If you are seeing this then an error has occured with YakYak.</p>
-        <p>To see what happened, <a href="javascript:void 0;" onclick="require('electron').remote.getCurrentWindow().webContents.openDevTools()">open the Inspector</a> and check the messages in the console tab.</p>
-        <p>Find if someone else is experiencing this by visiting
-          <script>
-            openIssues = function() {
-                require('electron').shell.openExternal("https://github.com/yakyak/yakyak/issues");
-            }
-          </script>
-          <a href="javascript:void 0;" onclick="openIssues()">
-            our issue tracker
-        </a> or create a new one if you are the first <i>(please include a screenshot of the console tab in the Inspector)</i>
-        </p>
-        <p>Sorry for this.</p>
-        <p><i>&nbsp; YakYak team and community</i></p>
-      </div>
+        -->
+        </style>
+        <div id="main-error">
+          <h1>An error has occured</h1>
+          <div>
+            <p>If you are seeing this then an error has occured with YakYak.</p>
+            <p>To see what happened, <a href="javascript:void 0;" onclick="require('electron').remote.getCurrentWindow().webContents.openDevTools()">open the Inspector</a> and check the messages in the console tab.</p>
+            <p>Find if someone else is experiencing this by visiting
+              <script>
+                openIssues = function() {
+                    require('electron').shell.openExternal("https://github.com/yakyak/yakyak/issues");
+                }
+              </script>
+              <a href="javascript:void 0;" onclick="openIssues()">
+                our issue tracker
+            </a> or create a new one if you are the first <i>(please include a screenshot of the console tab in the Inspector)</i>
+            </p>
+            <p>Sorry for this.</p>
+            <p><i>&nbsp; YakYak team and community</i></p>
+          </div>
+        </div>
     </div>
   </body>
 </html>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -32,7 +32,7 @@
       <h1>An error has occured</h1>
       <div>
         <p>If you are seeing this then an error has occured with YakYak.</p>
-        <p>To see what happened, <a href="javascript:void 0;" onclick="require('electron').remote.getCurrentWindow().webContents.openDevTools()">open the Inspector</a> and check if there is an error.</p>
+        <p>To see what happened, <a href="javascript:void 0;" onclick="require('electron').remote.getCurrentWindow().webContents.openDevTools()">open the Inspector</a> and check the messages in the console tab.</p>
         <p>Find if someone else is experiencing this by visiting
           <script>
             openIssues = function() {

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -41,7 +41,7 @@
           </script>
           <a href="javascript:void 0;" onclick="openIssues()">
             our issue tracker
-        </a> or create a new issue if you are the first <i>(please include a screenshot of the Inspector)</i>
+        </a> or create a new one if you are the first <i>(please include a screenshot of the console tab in the Inspector)</i>
         </p>
         <p>Sorry for this.</p>
         <p><i>&nbsp; YakYak team and community</i></p>

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -377,7 +377,7 @@ preloadInstagramPhoto = (href) ->
     return cache
 
 formatAttachment = (att) ->
-    console.log 'attachment', att if att.length > 0
+    # console.log 'attachment', att if att.length > 0
     if att?[0]?.embed_item?.type_
         data = extractProtobufStyle(att)
         return if not data


### PR DESCRIPTION
Changes:

- removes console logging of attachment in messages
- our current version of electron requires v6, so update .travis.yml
- users should always see something when an error appears

For the last change, the error window is static and defined explicitly in the `index.html`, which is replaced as soon as the app is ready to show.

The message is only shown if an exception is caught before the event `read-to-show`

How to test:

just delete app/node_modules/autosize/dist :) _(see #518)_