### PR TITLE
should correct #518 and #106

### DIFF
--- a/src/ui/views/convhead.coffee
+++ b/src/ui/views/convhead.coffee
@@ -6,7 +6,7 @@ module.exports = view (models) ->
   {conv, viewstate} = models
   conv_id = viewstate?.selectedConv
   c = conv[conv_id]
-  return if not c
+  return null if not c # region cannot take undefined
   name = nameofconv c
   div class:'headwrap', ->
     span class:'name', ->

--- a/src/ui/views/convhead.coffee
+++ b/src/ui/views/convhead.coffee
@@ -6,9 +6,9 @@ module.exports = view (models) ->
   {conv, viewstate} = models
   conv_id = viewstate?.selectedConv
   c = conv[conv_id]
-  return null if not c # region cannot take undefined
-  name = nameofconv c
   div class:'headwrap', ->
+    return if not c # region cannot take undefined
+    name = nameofconv c
     span class:'name', ->
       if conv.isQuiet(c)
             span class:'material-icons', 'notifications_off'


### PR DESCRIPTION
if it does not, then this is a necessary fix, as the same error will appear if the return clause is used.

The problem here is when trifl tries to render the region with an undefined `convhead` it throws an exception and stops rendering the rest of the interface.

This is avoided by moving the return clause to inside an empty `div` element

In the title in the word `should` as there is not yet feedback on this, but this can be tested by enforcing the return clause to be executed.

This is a fix that needs merging, even if not the root cause of those two bugs