### PR TITLE
move rendering of menu and dock out of redraw

### DIFF
--- a/src/ui/views/controller.coffee
+++ b/src/ui/views/controller.coffee
@@ -81,6 +81,7 @@ handle 'update:viewstate', ->
 
         menu viewstate
         dockicon viewstate
+        trayicon models
 
     else if viewstate.state == viewstate.STATE_ABOUT
         redraw()
@@ -124,7 +125,11 @@ redraw = ->
     input models
     convadd models
     startup models
-    trayicon models
+
+
+handle 'update:language', ->
+    menu viewstate
+    redraw()
 
 handle 'update:switchConv', ->
     messages.scrollToBottom()

--- a/src/ui/views/controller.coffee
+++ b/src/ui/views/controller.coffee
@@ -79,6 +79,9 @@ handle 'update:viewstate', ->
         else
             applayout.last null
 
+        menu viewstate
+        dockicon viewstate
+
     else if viewstate.state == viewstate.STATE_ABOUT
         redraw()
         about models
@@ -122,8 +125,6 @@ redraw = ->
     convadd models
     startup models
     trayicon models
-    menu viewstate
-    dockicon viewstate
 
 handle 'update:switchConv', ->
     messages.scrollToBottom()


### PR DESCRIPTION
Menu is rendering too many times if placed in `redraw()` function

This can be replicated by opening the menu and leaving it open a few seconds

This correction only renders menu when `viewstate` is updated as it originally was