### PR TITLE
throttle redraw to 20ms (50fps)

### DIFF
--- a/src/ui/views/controller.coffee
+++ b/src/ui/views/controller.coffee
@@ -125,6 +125,20 @@ redraw = ->
     menu viewstate
     dockicon viewstate
 
+throttle = (fn, time=10) ->
+    timeout = false
+    # return a throttled version of fn
+    # which executes on the trailing end of `time`
+    throttled = ->
+        return if timeout
+        timeout = setTimeout ->
+            fn()
+            timeout = false
+        ,
+            time
+
+redraw = throttle(redraw, 20)
+
 handle 'update:switchConv', ->
     messages.scrollToBottom()
 


### PR DESCRIPTION
Effectively reduces redraws on app start
from ~50 to <10 and avoids consecutive redraws
in general.