### PR TITLE
 Display timestamps in local locale (again)

### DIFF
--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -129,7 +129,7 @@ module.exports = view (models) ->
         div class:'historyinfo', ->
             if c.requestinghistory
                 pass 'Requesting history…', -> span class:'material-icons spin', 'donut_large'
-        moment.locale(i18n.getLocale())
+        moment.locale(window.navigator.language)
 
         last_seen = conv.findLastReadEventsByUser(c)
         last_seen_chat_ids_with_event = (last_seen, event) ->


### PR DESCRIPTION
I sent PR with moment.locale(window.navigator.language) a few months ago, and timestamps were displayed in my locale ("Šiandien 17:59" instead of "Today at 5:59 PM").
Does anyone know why it was changed? With moment.locale(i18n.getLocale()) timestamps here are again "Today at 5:59 PM", which I don't want.
OS is Linux.