### PR TITLE
Add the ability to generate rpm and deb packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ $ npm run deploy
 $ npm run deploy:darwin-x64
 ```
 
+If you have [fpm](https://github.com/jordansissel/fpm) installed (`gem install fpm`), you can also build RPM and Deb packages:
+
+```bash
+$ npm run deploy:linux-x64:rpm
+$ npm run deploy:linux-x64:deb
+```
+
 *note:* if you are building *Windows* binaries in *Linux* or *Mac OS X*, Wine (1.6 or higher) must be installed. It also requires a 32-bit Wine installation when building Windows 32-bit binary.
 
 ### Structure

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "deploy:win32": "gulp deploy:win32",
     "deploy:darwin": "gulp deploy:darwin",
     "deploy:linux-x64": "gulp deploy:linux-x64",
+    "deploy:linux-x64:deb": "gulp deploy:linux-x64:deb",
+    "deploy:linux-x64:rpm": "gulp deploy:linux-x64:rpm",
     "deploy:linux-ia32": "gulp deploy:linux-ia32",
+    "deploy:linux-ia32:deb": "gulp deploy:linux-ia32:deb",
+    "deploy:linux-ia32:rpm": "gulp deploy:linux-ia32:rpm",
     "deploy:win32-x64": "gulp deploy:win32-x64",
     "deploy:win32-ia32": "gulp deploy:win32-ia32",
     "deploy:darwin-x64": "gulp deploy:darwin-x64"

--- a/resources/linux/after-install.sh
+++ b/resources/linux/after-install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Link to the binary
+ln -sf /opt/yakyak/yakyak /usr/bin/yakyak
+
+# Update icon cache
+/bin/touch --no-create /usr/share/icons/hicolor &>/dev/null
+/usr/bin/gtk-update-icon-cache /usr/share/icons/hicolor &>/dev/null || :

--- a/resources/linux/after-remove.sh
+++ b/resources/linux/after-remove.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Delete the link to the binary
+rm -f /usr/bin/yakyak

--- a/resources/linux/app.desktop
+++ b/resources/linux/app.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=YakYak
+Comment=Chat client for Google Hangouts
+GenericName=YakYak
+Exec=/opt/yakyak/yakyak %U
+Icon=yakyak
+Terminal=false
+Type=Application
+StartupNotify=true
+#StartupWMClass=YakYak
+Keywords=hangouts;messenger
+Categories=Network;InstantMessaging
+X-GNOME-UsesNotifications=true


### PR DESCRIPTION
This uses fpm and the commands are `gulp deploy:linux-$arch:$type`.
For example, `gulp deploy:linux-x64:rpm` will create an RPM for
64-bit Fedora.

The generated packages don't list any dependencies yet.