### PR TITLE
Louder 'sending' message indication.

### DIFF
--- a/src/ui/css/yakyak/messages.less
+++ b/src/ui/css/yakyak/messages.less
@@ -131,6 +131,12 @@
                 &.placeholder {
                     opacity: 0.5;
                 }
+                &.placeholder:before {
+                  position: absolute;
+                  bottom: 100%;
+                  color: pink;
+                  content: 'sending...';
+                }
                 .attach {
                     margin-top: 4px;
                 }


### PR DESCRIPTION
Subjectively I find it's a little hard to tell when outgoing messages are still in transit (especially important when the other conversant(s) are on something slow like SMS). Here's my proposal for making that indication a little louder.