### PR TITLE
Use custom window frame for Linux/Windows platforms

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -127,6 +127,7 @@ app.on 'ready', ->
         icon: path.join __dirname, 'icons', icon_name
         show: false
         titleBarStyle: 'hidden-inset' if process.platform is 'darwin'
+        frame: false unless process.platform is 'darwin'
         # autoHideMenuBar : true unless process.platform is 'darwin'
     }
 

--- a/src/ui/css/yakyak/colors.less
+++ b/src/ui/css/yakyak/colors.less
@@ -50,9 +50,13 @@ html{
     .listhead button,
     .convhead .name,
     .controls .button,
-    .convhead .headwrap > .button,
+    .convhead .headwrap .optionwrapper > .button,
     .convadd .button{
       color: var(--black);
+    }
+
+    .convhead .win-buttons button{
+      background-color: var(--black);
     }
   }
 

--- a/src/ui/css/yakyak/convhead.less
+++ b/src/ui/css/yakyak/convhead.less
@@ -24,23 +24,28 @@
 			margin-right: 2px;
 		}
 	}
-	.headwrap > .button{
+	.headwrap > .optionwrapper{
+        -webkit-app-region: no-drag;
 		position: absolute;
 		right: 5px;
 		top: 0;
-		width: 50px;
-		cursor: pointer;
-		z-index: 2;
-		color: var(--white);
-		line-height: ~"calc(var(--headerbarheight) / var(--zoom))";
-		height: ~"calc(var(--headerbarheight) / var(--zoom))";
-		text-align: center;
-		.material-icons{
-			position: relative;
-			top: 7px;
-			font-size: ~"calc(24px / var(--zoom))";
-		}
-	}
+        z-index: 2;
+
+        > .button {
+            float: right;
+            width: 50px;
+            cursor: pointer;
+            color: var(--white);
+            line-height: ~"calc(var(--headerbarheight) / var(--zoom))";
+            height: ~"calc(var(--headerbarheight) / var(--zoom))";
+            text-align: center;
+            .material-icons {
+                position: relative;
+                top: 7px;
+                font-size: ~"calc(24px / var(--zoom))";
+            }
+        }
+    }
 
 	.convoptions{
 		background: var(--white);
@@ -87,4 +92,31 @@
 			}
 		}
 	}
+
+    .win-buttons{
+      float: right;
+      button{
+        -webkit-mask-size: ~"calc(20px / var(--zoom))";
+        -webkit-mask-position: center;
+        -webkit-mask-repeat: no-repeat;
+        -webkit-app-region: no-drag;
+        cursor: pointer;
+        padding: 0 1.5em 0 1.5em;;
+        height: ~"calc(var(--headerbarheight) / var(--zoom))";
+        background-color: var(--white);
+      }
+      #win-minimize{
+        -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' baseProfile='full'%3E%3Cpath d='M20 14H4v-4h16'/%3E%3C/svg%3E");
+      }
+      #win-maximize{
+        -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' baseProfile='full'%3E%3Cpath d='M4 4l16 .00001V20H4V4zm2.00001 4L6 18h12V8H6.00001z'/%3E%3C/svg%3E");
+      }
+      #win-restore{
+        -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath d='M4 8h4V4h12v12h-4v4H4V8m12 0v6h2V6h-8v2h6M6 12v6h8v-6H6z'/%3E%3C/svg%3E");
+        display: none;
+      }
+      #win-close{
+        -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' baseProfile='full'%3E%3Cpath d='M13.4579 12.0001l5.542 5.5432L19 19l-1.4574.0002-5.5417-5.5429-5.54305 5.5431L5 19l-.00008-1.4558 5.54398-5.544-5.54398-5.54255L5 4.99996l1.45671.00025 5.54409 5.54289 5.5429-5.54289L19 4.99996l-.0002 1.45834-5.5419 5.5418z'/%3E%3C/svg%3E");
+      }
+    }
 }

--- a/src/ui/css/yakyak/listhead.less
+++ b/src/ui/css/yakyak/listhead.less
@@ -12,6 +12,7 @@
     -webkit-user-select: none;
     z-index: 2; // hides the separator in the header
     button{
+        -webkit-app-region: no-drag;
         background: none;
         color: var(--white);
         height: ~"calc(var(--headerbarheight) / var(--zoom))";
@@ -27,6 +28,7 @@
     .minimal & span{
         display: none;
     }
+
 }
 
 .osx {

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -143,8 +143,7 @@ handle 'mutesoundnotification', ->
     viewstate.setMuteSoundNotification(not viewstate.muteSoundNotification)
 
 handle 'togglemenu', ->
-    mainWindow = remote.getCurrentWindow()
-    if mainWindow.isMenuBarVisible() then mainWindow.setMenuBarVisibility(false) else mainWindow.setMenuBarVisibility(true)
+    remote.Menu.getApplicationMenu().popup()
 
 handle 'setescapeclearsinput', (value) ->
     viewstate.setEscapeClearsInput(value)
@@ -515,3 +514,16 @@ handle 'openonsystemstartup', (open) ->
 
 handle 'initopenonsystemstartup', (isEnabled) ->
     viewstate.initOpenOnSystemStartup isEnabled
+
+handle 'minimize', ->
+    mainWindow = remote.getCurrentWindow()
+    mainWindow.minimize()
+
+handle 'resizewindow', ->
+    mainWindow = remote.getCurrentWindow()
+    console.log('what');
+    if mainWindow.isMaximized() then mainWindow.unmaximize() else mainWindow.maximize()
+
+handle 'close', ->
+    mainWindow = remote.getCurrentWindow()
+    mainWindow.close()

--- a/src/ui/views/convhead.coffee
+++ b/src/ui/views/convhead.coffee
@@ -1,5 +1,7 @@
 {nameofconv}  = require '../util'
 
+remote = require('electron').remote
+
 onclickaction = (a) -> (ev) -> action a
 
 module.exports = view (models) ->
@@ -15,9 +17,24 @@ module.exports = view (models) ->
       if conv.isStarred(c)
         span class:'material-icons', "star"
       name
-    div class:'button'
-    , title: i18n.__('conversation.options:Conversation Options')
-    , onclick:convoptions, -> span class:'material-icons', 'more_vert'
+    div class:"optionwrapper", ->
+      if process.platform isnt 'darwin'
+          div class:"win-buttons", ->
+            button id: "win-minimize"
+            , title:i18n.__('window.controls:Minimize')
+            , onclick: onclickaction('minimize')
+            button id: "win-maximize"
+            , title:i18n.__('window.controls:Maximize')
+            , onclick: onclickaction('resizewindow')
+            button id: "win-restore"
+            , title:i18n.__('window.controls:Restore')
+            , onclick: onclickaction('resizewindow')
+            button id: "win-close"
+            , title:i18n.__('window.controls:Close')
+            , onclick: onclickaction('close')
+      div class:'button'
+      , title: i18n.__('conversation.options:Conversation Options')
+      , onclick:convoptions, -> span class:'material-icons', 'more_vert'
     div class:'convoptions'
     , title:i18n.__('conversation.settings:Conversation settings'), ->
         div class:'button'
@@ -44,6 +61,22 @@ module.exports = view (models) ->
         , ->
             span class:'material-icons', 'info_outline'
             div class:'option-label', i18n.__('details:Details')
+
+if process.platform isnt 'darwin'
+    mainWindow = remote.getCurrentWindow()
+    mainWindow.on 'maximize', () ->
+        toggleHidden document.getElementById('win-maximize'), true
+        toggleHidden document.getElementById('win-restore'), false
+
+    mainWindow.on 'unmaximize', () ->
+        toggleHidden document.getElementById('win-maximize'), false
+        toggleHidden document.getElementById('win-restore'), true
+
+    toggleHidden = (element, hidden) ->
+        if hidden
+            element.style.display = 'none'
+        else
+            element.style.display = 'inline'
 
 convoptions  = ->
   {viewstate} = models


### PR DESCRIPTION
This is my attempt at fixing #211. Here's how it looks on Windows/Linux:

![image](https://cloud.githubusercontent.com/assets/247570/24320984/bb4959f4-1117-11e7-8002-e4fa54f740bd.png)

Clicking the hamburger will bring up the application menu as a context menu rather than as a separate row altogether.

I had to use SVG images from https://github.com/Templarian/MaterialDesign for the minimize/maximize/restore/close icons since Google doesn't include those in its font set. If you prefer a different way of integrating these icons, let me know.

This is my first time working in Electron so feedback is appreciated.