### PR TITLE
Only hide frame on Windows

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -129,7 +129,7 @@ app.on 'ready', ->
         icon: path.join __dirname, 'icons', icon_name
         show: false
         titleBarStyle: 'hidden-inset' if process.platform is 'darwin'
-        frame: false unless process.platform is 'darwin'
+        frame: false if process.platform is 'win32'
         # autoHideMenuBar : true unless process.platform is 'darwin'
     }
 

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -521,7 +521,6 @@ handle 'minimize', ->
 
 handle 'resizewindow', ->
     mainWindow = remote.getCurrentWindow()
-    console.log('what');
     if mainWindow.isMaximized() then mainWindow.unmaximize() else mainWindow.maximize()
 
 handle 'close', ->

--- a/src/ui/views/convhead.coffee
+++ b/src/ui/views/convhead.coffee
@@ -18,7 +18,7 @@ module.exports = view (models) ->
         span class:'material-icons', "star"
       name
     div class:"optionwrapper", ->
-      if process.platform isnt 'darwin'
+      if process.platform is 'win32'
           div class:"win-buttons", ->
             button id: "win-minimize"
             , title:i18n.__('window.controls:Minimize')
@@ -62,7 +62,7 @@ module.exports = view (models) ->
             span class:'material-icons', 'info_outline'
             div class:'option-label', i18n.__('details:Details')
 
-if process.platform isnt 'darwin'
+if process.platform is 'win32'
     mainWindow = remote.getCurrentWindow()
     mainWindow.on 'maximize', () ->
         toggleHidden document.getElementById('win-maximize'), true


### PR DESCRIPTION
Based on some conversation on #654, I no longer hide the frame on Linux. It's just not possible to predict how a window manager will handle rendering a frameless window. This essentially makes Linux look like it did on 1.4.2, but I kept the menubar as a context menu as I thought it looks better than displaying new row altogether.

Tested on MATE (Fedora), Gnome (Fedora), LXDE (Ubuntu), XFCE (Ubuntu), KDE (Ubuntu), and Ubuntu Unity

Also removed a console.log call I forgot about.