### PR TITLE
update of deprecated parameter names when packaging

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -61,7 +61,8 @@ deploy_options = {
     icon: path.join __dirname, 'src', 'icons', 'icon'
     out: outdeploy
     overwrite: true
-    'app-bundle-id': 'com.github.yakyak'
+    appBundleId: 'com.github.yakyak'
+    osxSign: true
     win32metadata: {
         CompanyName: 'Yakyak'
         ProductName: 'Yakyak'
@@ -71,7 +72,6 @@ deploy_options = {
         FileVersion: "#{json.version}"
         ProductVersion: "#{json.version}"
     }
-    'osx-sign': true
     arch:     archOpts.join ','
     platform: platformOpts.join ','
 }


### PR DESCRIPTION
```
WARNING: The app-bundle-id parameter is deprecated when used from JS, use appBundleId instead. It will be removed in the next major version.
WARNING: The osx-sign parameter is deprecated when used from JS, use osxSign instead. It will be removed in the next major version.
```