### PR TITLE
Removes error page as soon as app loads

### DIFF
--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -94,6 +94,10 @@ do ->
 #  note: could not use event here, as it must be defined
 #  before
 ipc.on 'ready-to-show', () ->
+    #
+    # remove initial error from DOM
+    elToRemove = window.document.getElementById("error-b4-app")
+    elToRemove.parentNode.removeChild(elToRemove)
     # get window object
     mainWindow = remote.getCurrentWindow()
     #

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <script src="app.js"></script>
-    <div>
+    <div id='error-b4-app'>
         <style TYPE="text/css">
         <!--
         #main-error {


### PR DESCRIPTION
The error page is only supposed to be seen if there is a problem when initially loading the app.

This was created to prevent "blank pages" issues, instead give the user more information on how to submit issues with relevant information