### PR TITLE
Feature/google voice sms

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -252,12 +252,19 @@ app.on 'ready', ->
     # sendchatmessage, executed sequentially and
     # retried if not sent successfully
     messageQueue = Q()
-    ipc.on 'sendchatmessage', (ev, msg) ->
+    ipc.on 'sendchatmessage', (ev, msg, googleVoice) ->
         {conv_id, segs, client_generated_id, image_id, otr, message_action_type} = msg
         sendForSure = -> Q.promise (resolve, reject, notify) ->
             attempt = ->
                 # console.log 'sendchatmessage', client_generated_id
                 delivery_medium = null
+
+                ## If the client isn't in google voice mode null is fine, otherwise specify google voice
+                if googleVoice
+                    delivery_medium = [2]
+                else
+                    delivery_medium = null ## Retain the null status to let the library upstream decide, currently this will always be BABEL
+
                 client.sendchatmessage(conv_id, segs, image_id, otr, client_generated_id, delivery_medium, message_action_type).then (r) ->
                       # console.log 'sendchatmessage:result', r?.created_event?.self_event_state?.client_generated_id
                     ipcsend 'sendchatmessage:result', r

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -316,15 +316,22 @@ app.on 'ready', ->
     # , false
 
     # we want to upload. in the order specified, with retry
-    ipc.on 'uploadimage', seqreq (ev, spec) ->
+    ipc.on 'uploadimage', seqreq (ev, spec, googleVoice) ->
         {path, conv_id, client_generated_id} = spec
         ipcsend 'uploadingimage', {conv_id, client_generated_id, path}
         client.uploadimage(path).then (image_id) ->
-            client.sendchatmessage conv_id, null, image_id, null, client_generated_id
+
+            delivery_medium = null
+            if googleVoice
+                delivery_medium = [2]
+            else
+                delivery_medium = null
+
+            client.sendchatmessage conv_id, null, image_id, null, client_generated_id, delivery_medium
     , true
 
     # we want to upload. in the order specified, with retry
-    ipc.on 'uploadclipboardimage', seqreq (ev, spec) ->
+    ipc.on 'uploadclipboardimage', seqreq (ev, spec, googleVoice) ->
         {pngData, conv_id, client_generated_id} = spec
         file = tmp.fileSync postfix: ".png"
         ipcsend 'uploadingimage', {conv_id, client_generated_id, path:file.name}
@@ -333,7 +340,12 @@ app.on 'ready', ->
         .then ->
             client.uploadimage(file.name)
         .then (image_id) ->
-            client.sendchatmessage conv_id, null, image_id, null, client_generated_id
+            delivery_medium = null
+            if googleVoice
+                delivery_medium = [2]
+            else
+                delivery_medium = null
+            client.sendchatmessage conv_id, null, image_id, null, client_generated_id, delivery_medium
         .then ->
             file.removeCallback()
     , true

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -124,10 +124,10 @@ handle 'selectConvIndex', (index = 0) ->
     viewstate.selectConvIndex index
     ipc.send 'setfocus', viewstate.selectedConv
 
-handle 'sendmessage', (txt = '') ->
+handle 'sendmessage', (txt = '', googleVoice) ->
     if !txt.trim() then return
     msg = userinput.buildChatMessage entity.self, txt
-    ipc.send 'sendchatmessage', msg
+    ipc.send 'sendchatmessage', msg, googleVoice
     conv.addChatMessagePlaceholder entity.self.id, msg
 
 handle 'toggleshowtray', ->
@@ -454,6 +454,9 @@ handle 'showconvmin', (doshow) ->
 handle 'setusesystemdateformat', (val) ->
 
     viewstate.setUseSystemDateFormat(val)
+
+handle 'enablegooglevoicemode', (enable) ->
+    viewstate.setGoogleVoice(enable)
 
 handle 'showconvthumbs', (doshow) ->
     viewstate.setShowConvThumbs doshow

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -256,7 +256,8 @@ handle 'uploadimage', (files) ->
             # add a placeholder for the image
             conv.addChatMessagePlaceholder entity.self.id, msg
             # and begin upload
-            ipc.send 'uploadimage', {path:file.path, conv_id, client_generated_id}
+            isGoogleMode = viewstate.googleVoiceMode
+            ipc.send 'uploadimage', {path:file.path, conv_id, client_generated_id, isGoogleMode}
     # clear value for upload image input
     document.getElementById('attachFile').value = ''
 
@@ -282,7 +283,8 @@ handle 'uploadpreviewimage', ->
     document.querySelector('#emoji-container').classList.remove('open')
     element.src = ''
     #
-    ipc.send 'uploadclipboardimage', {pngData, conv_id, client_generated_id}
+    isGoogleMode = viewstate.googleVoiceMode
+    ipc.send 'uploadclipboardimage', {pngData, conv_id, client_generated_id, isGoogleMode}
 
 handle 'uploadingimage', (spec) ->
     # XXX this doesn't look very good because the image

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -21,6 +21,7 @@ module.exports = exp = {
     pos: tryparse(localStorage.pos ? "[100, 100]")
     showConvMin: tryparse(localStorage.showConvMin) ? false
     showConvThumbs: tryparse(localStorage.showConvThumbs) ? true
+    googleVoiceMode: tryparse(localStorage.googleVoiceMode) ? false
     showAnimatedThumbs: tryparse(localStorage.showAnimatedThumbs) ? true
     showConvTime: tryparse(localStorage.showConvTime) ? true
     showConvLast: tryparse(localStorage.showConvLast) ? true
@@ -200,6 +201,11 @@ module.exports = exp = {
         @showConvMin = localStorage.showConvMin = doshow
         if doshow
             this.setShowConvThumbs(true)
+        updated 'viewstate'
+
+    setGoogleVoice: (enable) ->
+        return if @googleVoiceMode == enable
+        @googleVoiceMode = localStorage.googleVoiceMode = enable
         updated 'viewstate'
 
     setShowConvThumbs: (doshow) ->

--- a/src/ui/views/input.coffee
+++ b/src/ui/views/input.coffee
@@ -249,7 +249,7 @@ preparemessage = (ev) ->
         # Converts emojicodes (e.g. :smile:, :-) ) to unicode
         element.value = convertEmoji(element.value)
     #
-    action 'sendmessage', ev.value
+    action 'sendmessage', ev.value, models.viewstate.googleVoiceMode
     #
     # check if there is an image in preview
     img = document.getElementById "preview-img"

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -78,6 +78,13 @@ templateYakYak = (viewstate) ->
           accelerator: getAccelerator('openinspector')
           click: -> action 'devtools'
         }
+        {
+            type: 'checkbox'
+            label: i18n.__('menu.file.google:Google Voice Mode')
+            checked: viewstate.googleVoiceMode
+            enabled: viewstate.loggedin
+            click: (it) -> action 'enablegooglevoicemode', it.checked
+        }
         { type: 'separator' }
         {
             label: i18n.__('menu.file.logout:Logout')


### PR DESCRIPTION
This adds the capability for users to use yakyak while also wanting to send google voice SMS through a related hangouts conversation.

Internally the current YakYak setup is to always use the BABEL delivery method.  When you attempt to post a message to hangouts in a conversation that is using GOOGLE_VOICE it fails.  This adds a toggle option in the context menu as a way for user's to change the default behaviour of the library's delivery method.

NOTE:  This is probably seen as a "quick fix" for the issue, a full fix would be automatically detecting the delivery method for each conversation at a lower level.

Also, for Google Voice users setting the delivery method to GOOGLE_VOICE doesn't make BABEL conversations fail to send for some reason.  So this is more of a check it if you're mostly a google voice user.