### PR TITLE
opens outside links directly, google domain links stay same

### DIFF
--- a/src/locales/bn.json
+++ b/src/locales/bn.json
@@ -40,7 +40,8 @@
     "leave_confirm": "সত্যিই কথোপকথন ত্যাগ করতে চান?",
     "search": "লোকেদের অনুসন্ধান করুন",
     "new_message": "নতুন বার্তা",
-    "new_attachment": "New message received (image or video)"
+    "new_attachment": "New message received (image or video)",
+    "open_link": "Opening the link in the browser..."
   },
   "notification": {
     "one": "প্রজ্ঞাপন",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Opravdu opustit konverzaci?",
         "search": "Vyhledat osoby",
         "new_message": "Nová zpráva",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Oznámení",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Er du sikker på du ønsker at forlade samtalen?",
         "search": "Søg efter mennesker",
         "new_message": "Ny besked",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Notifikation",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Wollen Sie die Unterhaltung wirklich verlassen?",
         "search": "Kontakte suchen",
         "new_message": "Neue Nachricht",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Benachrichtigung",

--- a/src/locales/en.json.template
+++ b/src/locales/en.json.template
@@ -40,7 +40,8 @@
         "leave_confirm": "Really leave conversation?",
         "search": "Search people",
         "new_message": "New message received",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Notification",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -40,7 +40,8 @@
         "leave_confirm": "¿Dejar conversación definitivamente?",
         "search": "Buscar personas",
         "new_message": "Nuevo Mensaje",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Notificación",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Voulez-vous vraiment quitter la conversation ?",
         "search": "Chercher des contacts",
         "new_message": "Nouveau message",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Notification",

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -40,7 +40,8 @@
         "leave_confirm": "האם אתה בטוח שברצונך לעזור את השיחה?",
         "search": "חיפוש אנשים",
         "new_message": "הודעה חדשה",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "התראה",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Vuoi davvero lasciare la conversazione?",
         "search": "Cerca Persone",
         "new_message": "Nuovo Messaggio",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Notifica",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -40,7 +40,8 @@
         "leave_confirm": "本当にこのチャットをやめますか？",
         "search": "コンタクト検索",
         "new_message": "新メッセージ",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "通知",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -40,7 +40,8 @@
         "leave_confirm": "정말로 대화를 나가시겠습니까?",
         "search": "사용자 검색",
         "new_message": "새 메시지",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "알림",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -39,7 +39,9 @@
         "leave": "Gesprek verlaten",
         "leave_confirm": "Weet u zeker dat u dit gesprek wilt verlaten?",
         "search": "Contactpersonen doorzoeken",
-        "new_message": "Nieuw bericht"
+        "new_message": "Nieuw bericht",
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Melding",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -40,7 +40,8 @@
     "leave_confirm": "Na pewno chcesz opuścić rozmowę?",
     "search": "Szukaj uczestników",
     "new_message": "Nowa Wiadomość",
-    "new_attachment": "New message received (image or video)"
+    "new_attachment": "New message received (image or video)",
+    "open_link": "Opening the link in the browser..."
   },
   "notification": {
     "one": "Powiadomienie",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Deseja realmente sair da conversa?",
         "search": "Procurar pessoas",
         "new_message": "Nova mensagem recebida",
-        "new_attachment": "Nova mensagem recebida (imagem ou vídeo)"
+        "new_attachment": "Nova mensagem recebida (imagem ou vídeo)",
+        "open_link": "A abrir o link no browser..."
     },
     "notification": {
         "one": "Notificação",

--- a/src/locales/pt_BR.json
+++ b/src/locales/pt_BR.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Deseja realmente sair da conversa?",
         "search": "Procurar pessoas",
         "new_message": "Nova mensagem recebida",
-        "new_attachment": "New messagem recebida (imagem ou vídeo)"
+        "new_attachment": "Nova messagem recebida (imagem ou vídeo)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Notificação",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Părăsire conversație?",
         "search": "Caută persoane",
         "new_message": "Nou mesaj",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Notificare",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Покинуть диалог?",
         "search": "Поиск людей",
         "new_message": "Новое сообщение",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Уведомление",

--- a/src/locales/sl_SI.json
+++ b/src/locales/sl_SI.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Naj zapustim klepet?",
         "search": "Najdi ljudi",
         "new_message": "Novo sporočilo",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Obvestilo",

--- a/src/locales/sv_SE.json
+++ b/src/locales/sv_SE.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Vill du lämna konversationen?",
         "search": "Sök personer",
         "new_message": "Nytt meddelande",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Notifiering",

--- a/src/locales/ta.json
+++ b/src/locales/ta.json
@@ -40,7 +40,8 @@
         "leave_confirm": "உண்மையாகவே உரையாடலை விட்டு விலக வேண்டுமா?",
         "search": "மக்களை தேடு",
         "new_message": "புதிய செய்தியிடல்",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "அறிவிப்பு",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1,6 +1,6 @@
 {
     "__MyLocaleLanguage__": "Turkish",
-    "__maintaner__": "http://github.com/yakyak",
+    "__maintaner__": "http://github.com/hsnyildiz",
 
     "title": "YakYak - Hangouts Uygulaması",
     "description": "Google Hangouts için masaüstü uygulaması",
@@ -39,7 +39,9 @@
         "leave": "Görüşmeden ayrıl",
         "leave_confirm": "Görüşmeden ayrılmak istediğine emin misin?",
         "search": "Kişi ara",
-        "new_message": "Yeni Mesaj"
+        "new_message": "Yeni Mesaj",
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Bildirim",

--- a/src/locales/uk_UA.json
+++ b/src/locales/uk_UA.json
@@ -40,7 +40,8 @@
         "leave_confirm": "Покинути діалог?",
         "search": "Пошук людей",
         "new_message": "Нове повідомлення",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser..."
     },
     "notification": {
         "one": "Сповіщення",

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -72,7 +72,7 @@ onclick = (e) ->
 
     # Showing message with 3 second delay showing the user that something is happening
     notr {
-      html: "Opening the link in the browser..."
+      html: i18n.__ 'menu.help.about.title:Opening the link in the browser...'
       stay: 3000
     }
 

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -49,6 +49,10 @@ onclick = (e) ->
     if patt.test(address)
         address = address.replace(patt, '$3')
         address = unescape(address)
+        # this is a link outside google and can be opened directly
+        #  as there is no need for authentication
+        shell.openExternal(fixlink(address))
+        return
 
     if urlRegexp({exact: true}).test(address)
         unless url.parse(address).host?
@@ -65,6 +69,12 @@ onclick = (e) ->
     # so we can finally open it in the external browser :(
 
     xhr = new XMLHttpRequest
+
+    # Showing message with 3 second delay showing the user that something is happening
+    notr {
+      html: "Opening the link in the browser..."
+      stay: 3000
+    }
 
     xhr.onreadystatechange = (e) ->
         return if e.target.status is 0


### PR DESCRIPTION
closes #737

Revisiting links issue :)

I believe that links outside of google domains (videos, photos, etc..) are always redirected with a www.google.com/?url=....

This should be detected and opened directly, all others should be opened first in Yakyak to get an authenticated link that can be opened even if the user does not have an active google login.

Added a 3-second notification that link is being opened.. it just seemed that application froze or did nothing after clicking :)