### PR TITLE
Fix "Details" flowing out of the conversation settings wrapper at small window widths

### DIFF
--- a/src/ui/css/yakyak/convhead.less
+++ b/src/ui/css/yakyak/convhead.less
@@ -50,7 +50,7 @@
 	.convoptions{
 		background: var(--white);
 		width: 100%;
-		height: ~"calc(var(--headerbarheight) / var(--zoom))";
+		height: 100%;
 		line-height: ~"calc(var(--headerbarheight) / var(--zoom))";
 		position: relative;
 		z-index: 1;


### PR DESCRIPTION
Fixes #778.

<img src="https://user-images.githubusercontent.com/4658208/31408946-2eb2ffe6-add8-11e7-8472-53c626cf8604.png" width=400>
<img src="https://user-images.githubusercontent.com/4658208/31408947-2fa1619a-add8-11e7-8d32-408b24c3f7ea.png" width=400>
