### PR TITLE
adds tray options to View menu

### DIFF
--- a/src/locales/en.json.template
+++ b/src/locales/en.json.template
@@ -99,6 +99,7 @@
             "hide_dock": "Hide Dock icon",
             "fullscreen": "Toggle Fullscreen",
             "tray": {
+                "main": "Tray icon",
                 "show_tray": "Show tray icon",
                 "show_window": "Show window",
                 "toggle_minimize": "Toggle minimize to tray",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -99,6 +99,7 @@
             "hide_dock": "Esconder Ícone da Dock",
             "fullscreen": "Alternar Ecrã Inteiro",
             "tray": {
+                "main": "Icon no tray",
                 "show_tray": "Mostrar icon no tray",
                 "show_window": "Mostrar janela",
                 "toggle_minimize": "Mostrar janela / minimizar para tray",
@@ -163,7 +164,8 @@
                 "newer": "Uma versão mais recente encontra-se disponível, por favor atualize de %s para %s",
                 "license": "Licensa",
                 "authors": "Autores principais",
-                "contributors": "Contribuidores"
+                "contributors": "Contribuidores",
+                "startup": "Abrir no arranque"
             }
         },
         "window": {

--- a/src/ui/views/menu.coffee
+++ b/src/ui/views/menu.coffee
@@ -394,11 +394,30 @@ templateView = (viewstate) ->
         }
         { type: 'separator' }
         {
-            label: i18n.__('menu.view.tray.show_tray:Show tray icon')
-            type: 'checkbox'
-            enabled: not viewstate.hidedockicon
-            checked:  viewstate.showtray
-            click: -> action 'toggleshowtray'
+            label: i18n.__('menu.view.tray.main:Tray icon')
+            submenu: [
+                {
+                    label: i18n.__('menu.view.tray.show_tray:Show tray icon')
+                    type: 'checkbox'
+                    enabled: not viewstate.hidedockicon
+                    checked:  viewstate.showtray
+                    click: -> action 'toggleshowtray'
+                }
+                {
+                  label: i18n.__ "menu.view.tray.start_minimize:Start minimized to tray"
+                  type: "checkbox"
+                  enabled: viewstate.showtray
+                  checked: viewstate.startminimizedtotray
+                  click: -> action 'togglestartminimizedtotray'
+                }
+                {
+                    label: i18n.__ "menu.view.tray.close:Close to tray"
+                    type: "checkbox"
+                    enabled: viewstate.showtray
+                    checked: viewstate.closetotray
+                    click: -> action 'toggleclosetotray'
+                }
+            ]
         }
         {
           label: i18n.__('menu.view.escape.title:Escape key behavior')


### PR DESCRIPTION
This adds some options to the view menu that were hidden when right clicking in the tray.

I think we can maintain the options in the two places as to not break UI so much for previous users