### PR TITLE
Adds extra debugging information on console when running with --debug

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -67,6 +67,7 @@ if shouldQuit
     app.quit()
     return
 
+global.debug = debug
 global.i18nOpts = { opts: null, locale: null }
 
 # No more minimizing to tray, just close it

--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -23,6 +23,8 @@ window.onerror = (msg, url, lineNo, columnNo, error) ->
     hash = {msg, url, lineNo, columnNo, error}
     ipc.send 'errorInWindow', hash
 
+window.debug_flag = remote.getGlobal('debug')
+
 # expose some selected tagg functions
 trifl.tagg.expose window, ('ul li div span a i b u s button p label
 input table thead tbody tr td th textarea br pass img h1 h2 h3 h4

--- a/src/ui/views/convlist.coffee
+++ b/src/ui/views/convlist.coffee
@@ -14,6 +14,20 @@ module.exports = view (models) ->
             moment.locale(window.navigator.language)
         convs = conv.list()
         renderConv = (c) ->
+            #
+            if window.debug_flag
+                objs = []
+                for p in c.participant_data
+                    a_e = entity[p?.id?.chat_id]
+                    objs.push {
+                        'conv.fallback_name': p.fallback_name
+                        'conv.phone': p.phone_number
+                        'ent.display_name': a_e.display_name
+                        'ent.fallback_name': a_e.fallback_name
+                        entity: entity[p?.id?.chat_id]
+                        participant: p
+                    }
+                console.log('Conversation', c?.conversation_id?.id, objs...)
             # remove emoji suggestions on renderConv
             if document.querySelectorAll('.emoji-sugg-container').length
                 document.querySelectorAll('.emoji-sugg-container')[0].parentNode.removeChild(document.querySelectorAll('.emoji-sugg-container')[0])

--- a/src/ui/views/convlist.coffee
+++ b/src/ui/views/convlist.coffee
@@ -13,13 +13,15 @@ module.exports = view (models) ->
         else
             moment.locale(window.navigator.language)
         convs = conv.list()
+        debug_convs = {}
         renderConv = (c) ->
             #
             if window.debug_flag
-                objs = []
+                objs = {}
+                objs_names = []
                 for p in c.participant_data
                     a_e = entity[p?.id?.chat_id]
-                    objs.push {
+                    objs["#{p.fallback_name}__#{p?.id?.chat_id}"] = {
                         'conv.fallback_name': p.fallback_name
                         'conv.phone': p.phone_number
                         'ent.display_name': a_e.display_name
@@ -27,7 +29,9 @@ module.exports = view (models) ->
                         entity: entity[p?.id?.chat_id]
                         participant: p
                     }
-                console.log('Conversation', c?.conversation_id?.id, objs...)
+                    objs_names.push p.fallback_name
+                debug_convs["#{c?.conversation_id?.id}: #{objs_names.join('||')}"] = objs
+                #["#{p.fallback_name}_#{p?.id?.chat_id}"]
             # remove emoji suggestions on renderConv
             if document.querySelectorAll('.emoji-sugg-container').length
                 document.querySelectorAll('.emoji-sugg-container')[0].parentNode.removeChild(document.querySelectorAll('.emoji-sugg-container')[0])
@@ -97,6 +101,7 @@ module.exports = view (models) ->
             if starred.length > 0
                 div class: 'label', i18n.__ 'recent:Recent'
             others.forEach renderConv
+        console.log('Conversation_list:', debug_convs) if window.debug_flag
 
 # possible classes of messages
 MESSAGE_CLASSES = ['placeholder', 'chat_message',


### PR DESCRIPTION
Debug_flag is exposed in `window` object and allows to check if instance was run with `--debug`

This allows to add some extra debugging to the console to help find errors.

In this pull request it creates an array of the conversations with objects that have a readable form.

**@davibe do you think it makes sense to add this to master to help debugging problems?**

Or only keep this branch with some special releases when asking information from users

This was inspired by this issue #594 *(that is still not resolved)*