### PR TITLE
Toggle Off The Record 

### DIFF
--- a/src/locales/en.json.template
+++ b/src/locales/en.json.template
@@ -38,10 +38,15 @@
         "delete_confirm": "Really delete conversation?",
         "leave": "Leave conversation",
         "leave_confirm": "Really leave conversation?",
+        "history_on": "History has been turned on.",
+        "history_off": "History has been turned off.",
         "search": "Search people",
         "new_message": "New message received",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "toggle_history":"Toggle conversation history",
+        "toggle_history_on":"History is on",
+        "toggle_history_off":"History is off"
     },
     "notification": {
         "one": "Notification",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -341,6 +341,9 @@ app.on 'ready', ->
         client.setconversationnotificationlevel conv_id, level
     , true, (ev, conv_id, level) -> conv_id
 
+    ipc.on 'modifyotrstatus', seqreq (ev, conv_id, otr) ->
+        client.modifyotrstatus conv_id, otr, false, (ev, conv_id, otr) -> conv_id
+
     # retry
     ipc.on 'deleteconversation', seqreq (ev, conv_id) ->
         client.deleteconversation conv_id

--- a/src/ui/css/yakyak/colors.less
+++ b/src/ui/css/yakyak/colors.less
@@ -20,6 +20,8 @@ html{
   --tweettext: #fff;
   --instagrambg: #55acee;
   --instagramtext: #fff;
+  --historyoffdarkgrey: #b0bec5;
+  --historyoffaltgrey: #cfd8dc;
   //
   --headerbarheight: 35px;
 

--- a/src/ui/css/yakyak/messages.less
+++ b/src/ui/css/yakyak/messages.less
@@ -14,6 +14,22 @@
         text-align: center;
         color: var(--darkgrey);
     }
+    .otr {
+        margin-top: 15px;
+        display: block;
+        font-size: 12px;
+        text-align: center;
+        background-color: var(--altgrey);
+        color: var(--darkgrey);
+
+        .banner {
+            display: inline-block;
+            vertical-align: middle;
+            &.material-icons {
+                margin-right: 10px;
+            }
+        }
+    }
     .ugroup {
         margin-top: 17px;
         position: relative;
@@ -103,6 +119,9 @@
                 .message .instagram {
                     margin: 10px -35px 3px -10px;
                 }
+                &.historyoff {
+                    background: var(--historyoffdarkgrey);
+                }
             }
         }
         &.me {
@@ -130,6 +149,9 @@
             display: inline-block;
             text-align: left;
             overflow: hidden;
+            &.historyoff {
+                background-color: var(--historyoffaltgrey);
+            }
             .message {
                 font-family: var(--emojifont);
                 padding: 5px;

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -367,6 +367,14 @@ handle 'togglenotif', ->
     ipc.send 'setconversationnotificationlevel', conv_id, (if q then RING else QUIET)
     conv.setNotificationLevel conv_id, (if q then 'RING' else 'QUIET')
 
+handle 'toggleotr', ->
+    {OFF_THE_RECORD, ON_THE_RECORD} = Client.OffTheRecordStatus
+    conv_id = viewstate.selectedConv
+    return unless c = conv[conv_id]
+    q = conv.isOnTheRecord(c)
+    ipc.send 'modifyotrstatus', conv_id, (if q then OFF_THE_RECORD else ON_THE_RECORD)
+    conv.toggleOtr(c)
+
 handle 'togglestar', ->
     conv_id = viewstate.selectedConv
     return unless c = conv[conv_id]

--- a/src/ui/models/conv.coffee
+++ b/src/ui/models/conv.coffee
@@ -24,6 +24,7 @@ add = (conv) ->
     # participant_data contains entity information
     # we want in the entity lookup
     entity.add p for p in conv?.participant_data ? []
+    later -> action 'syncrecentconversations'
     lookup[id]
 
 rename = (conv, newname) ->
@@ -177,6 +178,17 @@ toggleStar = (c) ->
     localStorage.starredconvs = JSON.stringify(starredconvs);
     updated 'conv'
 
+isOnTheRecord = (c) -> return c?.otr_status == 'ON_THE_RECORD'
+
+toggleOtr = (c) ->
+    conv_id = c?.conversation_id?.id
+    return unless conv_id and conv = lookup[conv_id]
+    if isOnTheRecord(c)
+        conv.otr_status = "OFF_THE_RECORD"
+    else
+        conv.otr_status = "ON_THE_RECORD"
+    updated 'conv'
+
 isEventType = (type) -> (ev) -> !!ev[type]
 
 # a "hangout" is in google terms strictly an audio/video event
@@ -277,8 +289,10 @@ funcs =
     MAX_UNREAD: MAX_UNREAD
     unread: unread
     isQuiet: isQuiet
+    isOnTheRecord: isOnTheRecord
     isStarred: isStarred
     toggleStar: toggleStar
+    toggleOtr: toggleOtr
     isPureHangout: isPureHangout
     lastChanged: lastChanged
     addTyping: addTyping

--- a/src/ui/models/userinput.coffee
+++ b/src/ui/models/userinput.coffee
@@ -33,6 +33,9 @@ buildChatMessage = (sender, txt) ->
     if not delivery_medium
       delivery_medium = ClientDeliveryMediumType.BABEL
     action = null
+    otr_status = OffTheRecordStatus[conv[conv_id]?.otr_status]
+    if not otr_status?
+        otr_status = OffTheRecordStatus.ON_THE_RECORD
     if /^\/me\s/.test txt
         txt = txt.replace /^\/me/, sender.first_name
         action = MessageActionType.ME_ACTION
@@ -50,7 +53,7 @@ buildChatMessage = (sender, txt) ->
         client_generated_id
         ts
         image_id: undefined
-        otr: OffTheRecordStatus.ON_THE_RECORD
+        otr: otr_status
         message_action_type
         delivery_medium: [delivery_medium] # requires to be used as an array
     }

--- a/src/ui/views/convhead.coffee
+++ b/src/ui/views/convhead.coffee
@@ -47,6 +47,16 @@ module.exports = view (models) ->
                 span class:'material-icons', 'notifications'
             div class:'option-label', i18n.__n('notification:Notification', 1)
         div class:'button'
+        , title: i18n.__('conversation.toggle_history:Toggle conversation history')
+        , onclick:onclickaction('toggleotr')
+        , ->
+            if conv.isOnTheRecord(c)
+                span class:'material-icons', 'speaker_notes'
+                div class:'option-label', i18n.__('conversation.toggle_history_on:History is on')
+            else
+                span class:'material-icons', 'speaker_notes_off'
+                div class:'option-label', i18n.__('conversation.toggle_history_off:History is off')
+        div class:'button'
         , title:i18n.__('favorite.star_it:Star / unstar')
         , onclick:onclickaction('togglestar')
         , ->

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -88,13 +88,13 @@ onclick = (e) ->
     xhr.open("get", finalUrl)
     xhr.send()
 
-# helper method to group events in time/user bunches
+# helper method to group events in time/user/otr status bunches
 groupEvents = (es, entity) ->
     groups = []
     group = null
     user = null
     for e in es
-        if e.timestamp - (group?.end ? 0) > CUTOFF
+        if e.timestamp - (group?.end ? 0) > CUTOFF or e.otr_modification
             group = {
                 byuser: []
                 start: e.timestamp

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -273,6 +273,13 @@ drawMessage = (e, entity) ->
             else if hangout_event.event_type is 'END_HANGOUT'
                 span { class:'material-icons small', style }, 'call_end'
                 pass ' Call ended'
+        else if e.otr_modification
+            if e.otr_modification.new_otr_status is "OFF_THE_RECORD"
+                pass i18n.__ 'conversation.history_off:History has been turned off.'
+            else if e.otr_modification.new_otr_status is "ON_THE_RECORD"
+                pass i18n.__ 'conversation.history_on:History has been turned on.'
+            else 
+                console.log 'unhandled event type', e, entity
         else
             console.log 'unhandled event type', e, entity
 

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -94,7 +94,7 @@ groupEvents = (es, entity) ->
     group = null
     user = null
     for e in es
-        if e.timestamp - (group?.end ? 0) > CUTOFF or e.otr_modification
+        if e.timestamp - (group?.end ? 0) > CUTOFF or e.otr_modification or user?.event[0]?.otr_modification # create new group for otr modification events, and for any conversation after an otr mod event
             group = {
                 byuser: []
                 start: e.timestamp
@@ -117,7 +117,7 @@ groupEvents = (es, entity) ->
 
 # possible classes of messages
 MESSAGE_CLASSES = ['placeholder', 'chat_message',
-'conversation_rename', 'membership_change']
+'conversation_rename', 'membership_change', 'otr_modification']
 
 OBSERVE_OPTS =
     childList:true
@@ -167,12 +167,17 @@ module.exports = view (models) ->
                         div class:'ugroup me', ->
                             drawMessageAvatar u, sender, viewstate, entity
                             drawMeMessage e for e in events
+                    else if events[0].otr_modification
+                        div class:'otr', ->
+                            drawMessage(e, entity, u.cid) for e in events # only draws message regarding history being on/off
                     else
                         clz = ['ugroup']
                         clz.push 'self' if entity.isSelf(u.cid)
                         div class:clz.join(' '), ->
                             drawMessageAvatar u, sender, viewstate, entity
-                            div class:'umessages', ->
+                            innerClz = ['umessages']
+                            innerClz.push 'historyoff' if events[0].event_otr == 'OFF_THE_RECORD' 
+                            div class:innerClz.join(' '), ->
                                 drawMessage(e, entity) for e in events
 
                             # at the end of the events group we draw who has read any of its events
@@ -241,7 +246,7 @@ drawMeMessage = (e) ->
     div class:'message', ->
         e.chat_message?.message_content.segment[0].text
 
-drawMessage = (e, entity) ->
+drawMessage = (e, entity, cid=null) ->
     # console.log 'message', e.chat_message
     mclz = ['message']
     mclz.push c for c in MESSAGE_CLASSES when e[c]?
@@ -275,11 +280,19 @@ drawMessage = (e, entity) ->
                 pass ' Call ended'
         else if e.otr_modification
             if e.otr_modification.new_otr_status is "OFF_THE_RECORD"
-                pass i18n.__ 'conversation.history_off:History has been turned off.'
+                span class:'material-icons banner', 'query_builder'
+                if entity.isSelf(cid)
+                    p class:'banner', i18n.__('conversation.history_off.self:You turned history off.')
+                else
+                    p class:'banner', i18n.__('conversation.history_off.others:%s turned history off.', entity[cid].first_name)
             else if e.otr_modification.new_otr_status is "ON_THE_RECORD"
-                pass i18n.__ 'conversation.history_on:History has been turned on.'
+                span class:'material-icons banner', 'query_builder'
+                if entity.isSelf(cid)
+                    p class:'banner', i18n.__('conversation.history_on.self:You turned history on.')
+                else
+                    p class:'banner', i18n.__('conversation.history_on.others:%s turned history on.', entity[cid].first_name)
             else 
-                console.log 'unhandled event type', e, entity
+                console.log 'unhandled otr modification event type', e, entity
         else
             console.log 'unhandled event type', e, entity
 


### PR DESCRIPTION
Adds a button to the conversation head that can toggle the conversation's history status. It will display whether the conversation's history is currently on or off. 
When an otr modification event is sent/received, it will display a little banner in the conversation displaying who changed history on or off. 
Added some styling to change the background color of the the conversation bubbles when history is off (to mimic gmail/hangouts behavior).