### PR TITLE
fix hidden inset titleBar on macOS

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -133,7 +133,7 @@ app.on 'ready', ->
         "min-height": 420
         icon: path.join __dirname, 'icons', icon_name
         show: false
-        titleBarStyle: 'hidden-inset' if process.platform is 'darwin'
+        titleBarStyle: 'hiddenInset' if process.platform is 'darwin'
         frame: false if process.platform is 'win32'
         # autoHideMenuBar : true unless process.platform is 'darwin'
     }


### PR DESCRIPTION
Fixes #976 

Before:

<img width="562" alt="screen shot 2018-10-29 at 8 10 31 am" src="https://user-images.githubusercontent.com/4007345/47651883-6ac69300-db52-11e8-8db1-878b14fbc079.png">

After:

<img width="560" alt="screen shot 2018-10-29 at 8 09 30 am" src="https://user-images.githubusercontent.com/4007345/47651895-6f8b4700-db52-11e8-951f-ff5c8e910823.png">
