### PR TITLE
Fix own messages showing as unread.

### DIFF
--- a/src/ui/models/conv.coffee
+++ b/src/ui/models/conv.coffee
@@ -141,7 +141,7 @@ unread = (conv) ->
     return 0 unless typeof t == 'number'
     c = 0
     for e in conv?.event ? []
-        c++ if e.chat_message and e.timestamp > t
+        c++ if e.chat_message and e.timestamp > t and not entity.isSelf e.sender_id.chat_id
         return MAX_UNREAD if c >= MAX_UNREAD
     c
 


### PR DESCRIPTION
This fixes a problem where, if you send a message to someone in (for example) the hangouts app, it would show as unread in YakYak - even though I was the one who sent it. This will simply skip messages that are from self when getting the number of unread messages.