### PR TITLE
Fix popup showing wrong text when opening links.

### DIFF
--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -72,7 +72,7 @@ onclick = (e) ->
 
     # Showing message with 3 second delay showing the user that something is happening
     notr {
-      html: i18n.__ 'menu.help.about.title:Opening the link in the browser...'
+      html: i18n.__ 'conversation.open_link:Opening the link in the browser...'
       stay: 3000
     }
 


### PR DESCRIPTION
This fixes a minor bug in a popup that shows when you would open links that said 'About YakYak' instead of 'Opening in browser'.