### PR TITLE
Eliminate tray icon title in OSX

### DIFF
--- a/src/ui/views/trayicon.coffee
+++ b/src/ui/views/trayicon.coffee
@@ -32,7 +32,6 @@ create = () ->
     tray = new Tray trayIcons["read"]
     tray.currentImage = 'read'
     tray.setToolTip i18n.__('title:YakYak - Hangouts Client')
-    tray.setTitle i18n.__('title:YakYak - Hangouts Client')
     # Emitted when the tray icon is clicked
     tray.on 'click', -> action 'togglewindow'
 


### PR DESCRIPTION
tray.setTitle (presently macOS only) can be used to put some text next to a tray icon for status and such. It's probably not desirable in this case because it takes a huge amount of screen real estate. There's a tool tip already set which was probably the original intention.