### PR TITLE
Fix the Unicode mapping for 💩

### DIFF
--- a/src/ui/emojishortcode.coffee
+++ b/src/ui/emojishortcode.coffee
@@ -113,7 +113,7 @@ module.exports = {
     ":couple:": "\ud83d\udc6b",
     ":two_men_holding_hands:":  "\ud83d\udc6c",
     ":two_women_holding_hands:":    "\ud83d\udc6d",
-    ":poop:":   "\ud83d\udcaa",
+    ":poop:":   "\ud83d\udca9",
     ":point_left:": "\ud83d\udc48",
     ":point_right:":    "\ud83d\udc49",
     ":point_up:":   "\u261d",


### PR DESCRIPTION
This mapping was incorrectly set to [flexed biceps][1] instead of
[poop][2] which made it very confusing when trying to type it out.

[1]: https://www.fileformat.info/info/unicode/char/1f4aa/index.htm
[2]: https://www.fileformat.info/info/unicode/char/1f4a9/index.htm