### PR TITLE
Add show-hide preview for attachment images too

### DIFF
--- a/src/locales/bn.json
+++ b/src/locales/bn.json
@@ -41,7 +41,8 @@
     "search": "লোকেদের অনুসন্ধান করুন",
     "new_message": "নতুন বার্তা",
     "new_attachment": "New message received (image or video)",
-    "open_link": "Opening the link in the browser..."
+    "open_link": "Opening the link in the browser...",
+    "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
   },
   "notification": {
     "one": "প্রজ্ঞাপন",

--- a/src/locales/br.json
+++ b/src/locales/br.json
@@ -41,7 +41,8 @@
         "search": "Klask tud",
         "new_message": "Kemennadenn nevez degemeret",
         "new_attachment": "Kemennadenn nevez degemeret (skeudenn pe video)",
-        "open_link": "O tigeriñ an ere er merdeer..."
+        "open_link": "O tigeriñ an ere er merdeer...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Rebuzadur",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -41,7 +41,8 @@
         "search": "Vyhledat osoby",
         "new_message": "Nová zpráva",
         "new_attachment": "Obdržena nová zpráva (obraz nebo video)",
-        "open_link": "Otevírání odkazu v prohlížeči…"
+        "open_link": "Otevírání odkazu v prohlížeči…",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Oznámení",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -41,7 +41,8 @@
         "search": "Søg efter mennesker",
         "new_message": "Ny besked",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Notifikation",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -41,7 +41,8 @@
         "search": "Kontakte suchen",
         "new_message": "Neue Nachricht",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Benachrichtigung",

--- a/src/locales/en.json.template
+++ b/src/locales/en.json.template
@@ -42,7 +42,8 @@
         "search": "Search people",
         "new_message": "New message received",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Notification",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -41,7 +41,8 @@
         "search": "Buscar personas",
         "new_message": "Nuevo Mensaje",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Notificación",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -41,7 +41,8 @@
         "search": "Chercher des contacts",
         "new_message": "Nouveau message",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Notification",

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -41,7 +41,8 @@
         "search": "חיפוש אנשים",
         "new_message": "הודעה חדשה",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "התראה",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -40,8 +40,9 @@
         "leave_confirm": "Vuoi davvero lasciare la conversazione?",
         "search": "Cerca Persone",
         "new_message": "Nuovo Messaggio",
-        "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "new_attachment": "Nuovo Messaggio (immagine o video)",
+        "open_link": "Sto aprendo il collegamento sul browser...",
+        "no_preview_image_click_to_open": "Anteprima immagine disabilitata: clicca qui per vederla sul browser"
     },
     "notification": {
         "one": "Notifica",
@@ -90,7 +91,7 @@
             "copy_image": "Copia immagine",
             "select_all": "Seleziona tutto",
             "language": "Lingua (Language)",
-            "dateformat": "Use system date format"
+            "dateformat": "Usa il formato data del tuo sistema"
         },
         "view": {
             "title": "Visualizza",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -41,7 +41,8 @@
         "search": "コンタクト検索",
         "new_message": "新メッセージ",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "通知",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -41,7 +41,8 @@
         "search": "사용자 검색",
         "new_message": "새 메시지",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "알림",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -41,7 +41,8 @@
         "search": "Contactpersonen doorzoeken",
         "new_message": "Nieuw bericht",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Melding",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -41,7 +41,8 @@
     "search": "Szukaj uczestników",
     "new_message": "Nowa Wiadomość",
     "new_attachment": "New message received (image or video)",
-    "open_link": "Opening the link in the browser..."
+    "open_link": "Opening the link in the browser...",
+    "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
   },
   "notification": {
     "one": "Powiadomienie",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -42,7 +42,8 @@
         "search": "Procurar pessoas",
         "new_message": "Nova mensagem recebida",
         "new_attachment": "Nova mensagem recebida (imagem ou vídeo)",
-        "open_link": "A abrir o link no browser..."
+        "open_link": "A abrir o link no browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Notificação",

--- a/src/locales/pt_BR.json
+++ b/src/locales/pt_BR.json
@@ -41,7 +41,8 @@
         "search": "Procurar pessoas",
         "new_message": "Nova mensagem recebida",
         "new_attachment": "Nova messagem recebida (imagem ou vídeo)",
-        "open_link": "Abrindo o link no navegador..."
+        "open_link": "Abrindo o link no navegador...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Notificação",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -41,7 +41,8 @@
         "search": "Caută persoane",
         "new_message": "Nou mesaj",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Notificare",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -41,7 +41,8 @@
         "search": "Поиск людей",
         "new_message": "Новое сообщение",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Уведомление",

--- a/src/locales/sk.json
+++ b/src/locales/sk.json
@@ -40,7 +40,9 @@
         "leave_confirm": "Naozaj opustiť konverzáciu?",
         "search": "Vyhľadať osoby",
         "new_message": "Nová správa",
-        "new_attachment": "New message received (image or video)"
+        "new_attachment": "New message received (image or video)",
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Oznámenie",

--- a/src/locales/sl_SI.json
+++ b/src/locales/sl_SI.json
@@ -41,7 +41,8 @@
         "search": "Najdi ljudi",
         "new_message": "Novo sporočilo",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Obvestilo",

--- a/src/locales/sv_SE.json
+++ b/src/locales/sv_SE.json
@@ -41,7 +41,8 @@
         "search": "Sök personer",
         "new_message": "Nytt meddelande",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Notifiering",

--- a/src/locales/ta.json
+++ b/src/locales/ta.json
@@ -41,7 +41,8 @@
         "search": "மக்களை தேடு",
         "new_message": "புதிய செய்தியிடல்",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "அறிவிப்பு",

--- a/src/locales/te.json
+++ b/src/locales/te.json
@@ -120,6 +120,7 @@
 		"settings": "సంభాషణ యొక్క ప్రాధాన్యతలు",
 		"new_attachment": "క్రొత్త చిత్రం వచ్చింది",
 		"open_link": "లింకును మీ బ్రౌజర్‌లో తెరుస్తున్నాం",
+    	"no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser",
 		"edit": "సంభాషణను సవరించు",
 		"leave": "సంభాషణ నుండి నిష్క్రమించు",
 		"delete": "సంభాషణను తొలగించు"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -41,7 +41,8 @@
         "search": "Kişi ara",
         "new_message": "Yeni Mesaj",
         "new_attachment": "New message received (image or video)",
-        "open_link": "Opening the link in the browser..."
+        "open_link": "Opening the link in the browser...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Bildirim",

--- a/src/locales/uk_UA.json
+++ b/src/locales/uk_UA.json
@@ -41,7 +41,8 @@
         "search": "Пошук людей",
         "new_message": "Нове повідомлення",
         "new_attachment": "Отримано нове повідомлення (картинка або відео)",
-        "open_link": "Відкриваю лінк в браузері..."
+        "open_link": "Відкриваю лінк в браузері...",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "Сповіщення",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -41,7 +41,8 @@
         "search": "搜索用户",
         "new_message": "收到新消息",
         "new_attachment": "收到新消息 (图片或视频)",
-        "open_link": "在浏览器中打开链接……"
+        "open_link": "在浏览器中打开链接……",
+        "no_preview_image_click_to_open": "Image preview is disabled: click to open it in the browser"
     },
     "notification": {
         "one": "通知",

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -72,8 +72,8 @@ onclick = (e) ->
 
     # Showing message with 3 second delay showing the user that something is happening
     notr {
-      html: i18n.__ 'conversation.open_link:Opening the link in the browser...'
-      stay: 3000
+        html: i18n.__ 'conversation.open_link:Opening the link in the browser...'
+        stay: 3000
     }
 
     xhr.onreadystatechange = (e) ->
@@ -446,8 +446,11 @@ formatAttachment = (att) ->
     # here we assume attachments are only images
     if preload thumb
         div class:'attach', ->
-            a {href, onclick}, -> img src:thumb
-
+            a {href, onclick}, ->
+                if models.viewstate.showImagePreview
+                    img src:thumb
+                else
+                    i18n.__('conversation.no_preview_image_click_to_open:Image preview is disabled: click to open it in the browser')
 
 handle 'loadedimg', ->
     # allow controller to record current position


### PR DESCRIPTION
This is a feature #620 follow-up.
A new i18n string is added: 'no_preview_image_click_to_open'.