### PR TITLE
Work around window position not always being restored properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6426,6 +6426,53 @@
         }
       }
     },
+    "node-persist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-2.1.0.tgz",
+      "integrity": "sha1-5lK784haBNrWo1PXQXYXfIORRwc=",
+      "requires": {
+        "is-absolute": "^0.2.6",
+        "mkdirp": "~0.5.1",
+        "q": "~1.1.1"
+      },
+      "dependencies": {
+        "is-absolute": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+          "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+          "requires": {
+            "is-relative": "^0.2.1",
+            "is-windows": "^0.2.0"
+          }
+        },
+        "is-relative": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+          "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+          "requires": {
+            "is-unc-path": "^0.1.1"
+          }
+        },
+        "is-unc-path": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+          "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+          "requires": {
+            "unc-path-regex": "^0.1.0"
+          }
+        },
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        },
+        "q": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+          "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok="
+        }
+      }
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "request": "^2.88.0",
     "tmp": "^0.1.0",
     "trifl": "0.0.10",
-    "uber-url-regex": "^5.0.9"
+    "uber-url-regex": "^5.0.9",
+    "node-persist": "^2.1.0"
   },
   "optionalDependencies": {
     "electron-installer-flatpak": "^0.6.0"

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -7,6 +7,7 @@ path      = require 'path'
 tmp       = require 'tmp'
 session   = require('electron').session
 log       = require('bog');
+windowState = require('./ui/models/windowstate')
 
 [drive, path_parts...] = path.normalize(__dirname).split(path.sep)
 global.YAKYAK_ROOT_DIR = [drive, path_parts.map(encodeURIComponent)...].join('/')
@@ -121,14 +122,18 @@ app.on 'ready', ->
                 process.env[t.env] ?= if purl then "http://#{purl}" else ""
                 rs()
 
+    bounds = windowState.getBounds()
+
     icon_name = if process.platform is 'win32'
         'icon@2.png'
     else
         'icon@32.png'
     # Create the browser window.
     mainWindow = new BrowserWindow {
-        width: 730
-        height: 590
+        x: bounds.x
+        y: bounds.y
+        width: bounds.width
+        height: bounds.height
         "min-width": 620
         "min-height": 420
         icon: path.join __dirname, 'icons', icon_name

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -1,4 +1,5 @@
 Client = require 'hangupsjs'
+windowState = require './windowstate'
 
 merge   = (t, os...) -> t[k] = v for k,v of o when v not in [null, undefined] for o in os; t
 
@@ -144,11 +145,13 @@ module.exports = exp = {
             later -> action 'updatewatermark'
 
     setSize: (size) ->
+        windowState.setSize size
         localStorage.size = JSON.stringify(size)
         @size = size
         # updated 'viewstate'
 
     setPosition: (pos) ->
+        windowState.setPosition pos
         localStorage.pos = JSON.stringify(pos)
         @pos = pos
         # updated 'viewstate'

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -18,8 +18,6 @@ module.exports = exp = {
     selectedConv: localStorage.selectedConv
     lastActivity: null
     leftSize: tryparse(localStorage.leftSize) ? 240
-    size: tryparse(localStorage.size ? "[940, 600]")
-    pos: tryparse(localStorage.pos ? "[100, 100]")
     showConvMin: tryparse(localStorage.showConvMin) ? false
     showConvThumbs: tryparse(localStorage.showConvThumbs) ? true
     showAnimatedThumbs: tryparse(localStorage.showAnimatedThumbs) ? true
@@ -146,14 +144,10 @@ module.exports = exp = {
 
     setSize: (size) ->
         windowState.setSize size
-        localStorage.size = JSON.stringify(size)
-        @size = size
         # updated 'viewstate'
 
     setPosition: (pos) ->
         windowState.setPosition pos
-        localStorage.pos = JSON.stringify(pos)
-        @pos = pos
         # updated 'viewstate'
 
     setLeftSize: (size) ->

--- a/src/ui/models/windowstate.coffee
+++ b/src/ui/models/windowstate.coffee
@@ -1,0 +1,19 @@
+Client = require 'hangupsjs'
+settings = require('node-persist')
+
+{throttle, later, tryparse, autoLauncher} = require '../util'
+
+settings.initSync()
+
+module.exports = exp = {
+    setSize: (size) ->
+        settings.setItemSync('size', JSON.stringify(size))
+
+    setPosition: (pos) ->
+        settings.setItemSync('pos', JSON.stringify(pos))
+
+    getBounds: () ->
+        size = tryparse(settings.getItemSync('size') ? "[940, 600]")
+        pos = tryparse(settings.getItemSync('pos') ? "[100, 100]")
+        return {x: pos[0], y: pos[1], width: size[0], height: size[1]}
+}

--- a/src/ui/views/controller.coffee
+++ b/src/ui/views/controller.coffee
@@ -42,69 +42,6 @@ handle 'update:viewstate', ->
     setLeftSize viewstate.leftSize
     setConvMin viewstate.showConvMin
     if viewstate.state == viewstate.STATE_STARTUP
-        #
-        #
-        # It will not allow the window to be placed offscreen (fully or partial)
-        #
-        # For that it needs to iterate on all screens and see if position is valid.
-        #  If it is not valid, then it will approximate the best position possible
-        if Array.isArray viewstate.pos
-            # uses max X and Y as a fallback method in case it can't be placed on any
-            #  current display, by approximating a new position
-            maxX = maxY = maxW = maxH = 0
-            reposition = false
-            # helper variable to determine valid coordinates to be used, initialized with
-            #  desired coordinates
-            xWindowPos = viewstate.pos[0]
-            yWindowPos = viewstate.pos[1]
-            # window size to be used in rounding the position, i.e. avoiding partial offscreen
-            winSize = remote.getCurrentWindow().getSize()
-            # iterate on all displays to see if the desired position is valid
-            for screen in remote.screen.getAllDisplays()
-                # get bounds of each display
-                {width, height} = screen.workAreaSize
-                {x, y} = screen.workArea
-
-                # see if this improves on maxY and maxX
-                if x + width > maxW
-                    maxX = x
-                    maxW = x + width
-                if y + height > maxH
-                    maxY = y
-                    maxH = y + height
-
-
-                # check if window will be placed in this display
-                if xWindowPos >= x and xWindowPos < x + width and yWindowPos >= y and yWindowPos < y + height
-                    # if window will be partially placed outside of this display, then it will
-                    #  move it all inside the display
-
-                    # for X
-                    if winSize[0] > width
-                        xWindowPos = x
-                    else if xWindowPos > x + width - winSize[0] / 2
-                        xWindowPos = x + width - winSize[0] / 2
-
-                    # for Y
-                    if winSize[1] > height
-                        yWindowPos = y
-                    else if yWindowPos > y + width - winSize[1] / 2
-                        yWindowPos = y + width - winSize[1] / 2
-                    # making sure no negative positions on displays
-                    xWindowPos = Math.max(xWindowPos, x)
-                    yWindowPos = Math.max(yWindowPos, y)
-                    #
-                    reposition = true # coordinates have been calculated
-                    break # break the loop
-            if not reposition
-                xWindowPos = maxW - winSize[0] if xWindowPos > maxW
-                yWindowPos = maxY if yWindowPos > maxH
-                xWindowPos = Math.max(xWindowPos, maxX)
-                yWindowPos = Math.max(yWindowPos, maxY)
-
-            if Array.isArray viewstate.pos
-                if viewstate.pos[0] != xWindowPos or viewstate.pos[1] != yWindowPos
-                    later -> remote.getCurrentWindow().setPosition(xWindowPos, yWindowPos)
         # only render startup
         startup(models)
 

--- a/src/ui/views/controller.coffee
+++ b/src/ui/views/controller.coffee
@@ -42,8 +42,6 @@ handle 'update:viewstate', ->
     setLeftSize viewstate.leftSize
     setConvMin viewstate.showConvMin
     if viewstate.state == viewstate.STATE_STARTUP
-        if Array.isArray viewstate.size
-            later -> remote.getCurrentWindow().setSize viewstate.size...
         #
         #
         # It will not allow the window to be placed offscreen (fully or partial)
@@ -103,7 +101,10 @@ handle 'update:viewstate', ->
                 yWindowPos = maxY if yWindowPos > maxH
                 xWindowPos = Math.max(xWindowPos, maxX)
                 yWindowPos = Math.max(yWindowPos, maxY)
-            later -> remote.getCurrentWindow().setPosition(xWindowPos, yWindowPos)
+
+            if Array.isArray viewstate.pos
+                if viewstate.pos[0] != xWindowPos or viewstate.pos[1] != yWindowPos
+                    later -> remote.getCurrentWindow().setPosition(xWindowPos, yWindowPos)
         # only render startup
         startup(models)
 


### PR DESCRIPTION
This fixes an issue where the window position isn't always restored properly. For example, I'm running Linux and have a panel at the top of my primary monitor, but not on my secondary. If I move yakyak to the top of my secondary monitor, the next time I open it up, it won't be restored at the top of the secondary monitor, but will instead be a few pixels down from the top, corresponding to the bottom of the top bar on my primary monitor.
The fix actually allows the system to handle the positioning, so the part where it checks if it's within the bounds of the monitors and such isn't necessary anymore.

I haven't noticed any issues myself, and it seems to work pretty much identical to how it did before, without the overhead of the manual checking.

Do let me know if you want any changes to be done, or if more testing is required.