### PR TITLE
Add Arch Linux (Pacman) package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,12 @@ $ npm run deploy
 $ npm run deploy:darwin-x64
 ```
 
-If you have [fpm](https://github.com/jordansissel/fpm) installed (`gem install fpm`), you can also build RPM and Deb packages:
+If you have [fpm](https://github.com/jordansissel/fpm) installed (`gem install fpm`), you can also build RPM, Deb, or Arch packages:
 
 ```bash
 $ npm run deploy:linux-x64:rpm
 $ npm run deploy:linux-x64:deb
+$ npm run deploy:linux-x64:pacman
 ```
 
 *note:* if you are building *Windows* binaries in *Linux* or *Mac OS X*, Wine (1.6 or higher) must be installed. It also requires a 32-bit Wine installation when building Windows 32-bit binary.

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -327,7 +327,7 @@ platformOpts.map (plat) ->
     #
 
 archOpts.forEach (arch) ->
-    ['deb', 'rpm'].forEach (target) ->
+    ['deb', 'rpm', 'pacman'].forEach (target) ->
         gulp.task "deploy:linux-#{arch}:#{target}:nodep", (done) ->
             if arch is 'ia32'
                 archName = 'i386'
@@ -336,7 +336,12 @@ archOpts.forEach (arch) ->
             else
                 archName = 'x86_64'
 
-            packageName = json.name + '-VERSION-linux-ARCH.' + target
+            if target == 'pacman'
+                suffix = 'tar.gz'
+            else
+                suffix = target
+
+            packageName = json.name + '-VERSION-linux-ARCH.' + suffix
             iconArgs = [16, 32, 48, 128, 256, 512].map (size) ->
                 if size < 100
                     src = "0#{size}"

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "deploy:linux-x64:deb": "gulp deploy:linux-x64:deb",
     "deploy:linux-x64:flatpak": "gulp deploy:linux-x64:flatpak",
     "deploy:linux-x64:rpm": "gulp deploy:linux-x64:rpm",
+    "deploy:linux-x64:pacman": "gulp deploy:linux-x64:pacman",
     "deploy:linux-ia32": "gulp deploy:linux-ia32",
     "deploy:linux-ia32:deb": "gulp deploy:linux-ia32:deb",
     "deploy:linux-ia32:flatpak": "gulp deploy:linux-ia32:flatpak",
     "deploy:linux-ia32:rpm": "gulp deploy:linux-ia32:rpm",
+    "deploy:linux-ia32:pacman": "gulp deploy:linux-ia32:pacman",
     "deploy:win32-x64": "gulp deploy:win32-x64",
     "deploy:win32-ia32": "gulp deploy:win32-ia32",
     "deploy:darwin-x64": "gulp deploy:darwin-x64"


### PR DESCRIPTION
fpm already supports generating pacman packages, so just requires adding a task to build it.

```bash
$ export XZ_DEFAULTS="-T0"
$ gulp deploy:linux-x64:pacman
...
Created archive (/home/john/Projects/yakyak/dist/yakyak-1.5.5-linux-x64.tar.gz)
[16:45:34] Finished 'deploy:linux-x64:nodep' after 18 s
[16:45:34] Finished 'deploy:linux-x64' after 24 s
[16:45:34] Starting 'deploy:linux-x64:pacman:nodep'...
[16:45:35] Finished 'deploy:linux-x64:pacman:nodep' after 614 ms
[16:45:35] Finished 'deploy:linux-x64:pacman' after 24 s
Created pacman (yakyak-VERSION-linux-ARCH.tar.gz)
Done in 43.95s.

$ cd dist/ && sudo pacman -U yakyak-1.5.5-linux-x86_64.tar.gz 
loading packages...
warning: yakyak-1.5.5-1 is up to date -- reinstalling
resolving dependencies...
looking for conflicting packages...

Packages (1) yakyak-1.5.5-1

Total Installed Size:  239.48 MiB
Net Upgrade Size:        0.00 MiB

:: Proceed with installation? [Y/n] 
```
