### PR TITLE
Fix macOS titlebar issue

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -149,7 +149,7 @@ app.on 'ready', ->
     }
 
     if process.platform is 'darwin'
-        windowOpts.titleBarStile = 'hiddenInset'
+        windowOpts.titleBarStyle = 'hiddenInset'
 
     if process.platform is 'win32'
         windowOpts.frame = false


### PR DESCRIPTION
1.5.9 introduced a regression where the app titlebar/window buttons are no longer inset like they should be on macOS (see screenshots). This PR fixes the innocent typo that's responsible 😄 

### Before:
![before](https://user-images.githubusercontent.com/1936865/86196787-fb245a80-bb21-11ea-80d3-4153e3cea7d8.png)

### After:
![after](https://user-images.githubusercontent.com/1936865/86196794-ff507800-bb21-11ea-9f9f-1f716d479df6.png)
