### PR TITLE
Version start

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -20,6 +20,7 @@ tmp.setGracefulCleanup()
 app = require('electron').app
 
 console.log('Starting Yakyak v' + app.getVersion() + '...')
+console.log('  using hangupsjs v' + Client.VERSION) if Client.VERSION
 console.log('--------')
 app.disableHardwareAcceleration() # was using a lot of resources needlessly
 app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required')

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -20,6 +20,7 @@ tmp.setGracefulCleanup()
 app = require('electron').app
 
 console.log('Starting Yakyak v' + app.getVersion() + '...')
+console.log('--------')
 app.disableHardwareAcceleration() # was using a lot of resources needlessly
 app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required')
 

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -18,6 +18,8 @@ debug = process.argv.includes '--debug'
 tmp.setGracefulCleanup()
 
 app = require('electron').app
+
+console.log('Starting Yakyak v' + app.getVersion() + '...')
 app.disableHardwareAcceleration() # was using a lot of resources needlessly
 app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required')
 


### PR DESCRIPTION
@HomerSp does this make sense? _(is it well implemented?)_

I just asked a user for a screenshot and I figured out that having the version would help alot in the future, along with hangusjs'.

This assumes we also add the following to `hangupsjs`

```
Client.VERSION            = JSON.parse(fs.readFileSync(syspath.normalize syspath.join(__dirname, '..', 'package.json'))).version
```