### PR TITLE
Fix endless scrolling when scrolling through chat history

### DIFF
--- a/src/ui/views/applayout.coffee
+++ b/src/ui/views/applayout.coffee
@@ -27,12 +27,20 @@ onScroll = throttle 20, (ev) ->
     el = ev.target
     child = el.children[0]
 
+    # use the saved scroll value if we have one
+    if el.hasAttribute('scrolltop')
+        el.scrollTop = el.getAttribute('scrolltop')
+        el.removeAttribute('scrolltop')
+
     # calculation to see whether we are at the bottom with a tolerance value
     atbottom = (el.scrollTop + el.offsetHeight) >= (child.offsetHeight - 10)
     action 'atbottom', atbottom
 
     # check whether we are at the top with a tolerance value
-    attop = el.scrollTop <= (el.offsetHeight / 2)
+    if el.scrollTop < 0
+        attop = child.offsetHeight - el.offsetHeight + el.scrollTop <= el.offsetHeight / 2
+    else
+        attop = el.scrollTop <= (el.offsetHeight / 2)
     action 'attop', attop
 
 addClass = (el, cl) ->
@@ -131,18 +139,11 @@ do ->
         return last
 
     exp.recordMainPos = ->
-        el = lastVisibleMessage()
-        id = el?.id
-        return unless el and id
-        ofs = topof el
+        ofs = document.querySelector('.main').scrollTop
 
     exp.adjustMainPos = ->
-        return unless id and ofs
-        el = document.getElementById id
-        nofs = topof el
-        # the size of the inserted elements
-        inserted = nofs - ofs
-        screl = document.querySelector('.main')
-        screl.scrollTop = screl.scrollTop + inserted
+        return unless ofs
+        document.querySelector('.main').scrollTop = ofs
+        document.querySelector('.main').setAttribute('scrolltop', ofs)
         # reset
         id = ofs = null

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -293,7 +293,7 @@ scrollToBottom = module.exports.scrollToBottom = ->
     # ensure we're scrolled to bottom
     el = document.querySelector('.main')
     # to bottom
-    el.scrollTop = Number.MAX_SAFE_INTEGER
+    el.scrollTop = 0
 
 
 ifpass = (t, f) -> if t then f else pass


### PR DESCRIPTION
This fixes an issue in v1.5.10 where scrolling up through the chat history would cause it to endlessly load older messages.
The problem happens because, I'm guessing, in electron 11 an element that has flex-flow as column-reverse will also reverse the scrollTop value - meaning it starts at 0 when not scrolled and then it goes down into the negatives as you start scrolling.
This change also means that we no longer have to calculate the position of the top message when adding older messages to the view, since it's based on the bottom of the view. So I changed this around to only save the scrollTop and then set that back when we added the older messages. For whatever reason the scroll position still changes when adding items, so we do have to save it. I also had to set the saved scroll top position at a later time as just setting it in adjustMainPos meant that it would be overridden.