### PR TITLE
Fix the presence indicator not working anymore

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -381,13 +381,13 @@ app.on 'ready', ->
     # retried if not sent successfully
     ipc.on 'querypresence', seqreq (ev, id) ->
         client.querypresence(id).then (r) ->
-            ipcsend 'querypresence:result', r.presence_result[0]
+            ipcsend 'querypresence:result', r.presenceResult[0]
         , false, -> 1
 
     ipc.on 'initpresence', (ev, l) ->
         for p, i in l when p != null
             client.querypresence(p.id).then (r) ->
-                ipcsend 'querypresence:result', r.presence_result[0]
+                ipcsend 'querypresence:result', r.presenceResult[0]
             , false, -> 1
 
     # no retry, only one outstanding call

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -69,7 +69,8 @@ handle 'watermark', (ev) ->
     conv.addWatermark ev
 
 handle 'presence', (ev) ->
-    entity.setPresence ev[0][0][0][0], if ev[0][0][1][1] == 1 then true else false
+    entity.setLastSeen ev[0][0][0][0], Math.floor(ev[0][0][1][9] / 1000000)
+    entity.updatePresence()
 
 # handle 'self_presence', (ev) ->
 #     console.log 'self_presence', ev
@@ -79,9 +80,9 @@ handle 'querypresence', (id) ->
 
 handle 'setpresence', (r) ->
     if not r?.presence?.available?
-        console.log "setpresence: User '#{nameof entity[r?.user_id?.chat_id]}' does not show his/hers/it status", r
+        console.log "setpresence: User '#{nameof entity[r?.userId?.chatId]}' does not show his/hers/it status", r
     else
-        entity.setPresence r.user_id.chat_id, r?.presence?.available
+        entity.setPresence r.userId.chatId, r?.presence?.available
 
 handle 'update:unreadcount', ->
     console.log 'update'
@@ -198,6 +199,7 @@ handle 'showwindow', ->
 sendsetpresence = throttle 10000, ->
     ipc.send 'setpresence'
     ipc.send 'setactiveclient', true, 15
+    entity.updatePresence()
 resendfocus = throttle 15000, -> ipc.send 'setfocus', viewstate.selectedConv
 
 # on every keep alive signal from hangouts

--- a/src/ui/models/entity.coffee
+++ b/src/ui/models/entity.coffee
@@ -68,7 +68,27 @@ funcs =
         lookup[id].presence = p
         updated 'entity'
 
+    setLastSeen: (id, lastseen) ->
+        return needEntity(id) if not lookup[id]
+        lookup[id].lastseen = lastseen
+        lookup[id].presence = true
+        updated 'entity'
+
     isSelf: (chat_id) -> return !!lookup.self and lookup[chat_id] == lookup.self
+
+    updatePresence: ->
+        if lookup.self?.lastseen?
+            changed = false
+            cutoff = lookup.self.lastseen - (60 * 15)
+            for k, v of lookup when v.presence
+                if !v.lastseen?
+                    v.lastseen = lookup.self.lastseen
+
+                if v.lastseen <= cutoff
+                    v.presence = false
+                    changed = true
+
+            updated 'entity' if changed
 
     _reset: ->
         delete lookup[k] for k, v of lookup when typeof v == 'object'


### PR DESCRIPTION
As can be seen in eg #1242 the presence indicator does not work currently. This is caused by a few different issues, for one they did some server-side changes to some object names, causing the initial presence loading to not work. They also completely removed the presence value from the server event, and it is instead replaced by a null. I fixed this by instead relying on the timestamp in that message, which will be checked against the self presence timestamp and if it's older than an offset (15 minutes currently because that seems to be what it is in the web app) the user will be marked as not present.