### PR TITLE
Disable avatar click handler

### DIFF
--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -205,7 +205,7 @@ module.exports = view (models) ->
 
 drawMessageAvatar = (u, sender, viewstate, entity) ->
     div class: 'sender-wrapper', ->
-        a href:linkto(u.cid), title: sender, {onclick}, class:'sender', ->
+        a title: sender, class:'sender', ->
             drawAvatar(u.cid, viewstate, entity)
         span sender
 


### PR DESCRIPTION
This is a simple PR that disables the click handler for the avatars in conversations due to Google+ being shut down and the URL not being valid anymore. This also matches the Hangouts web app which doesn't do anything when you click the avatar.