### PR TITLE
Fix potential startup issue if the locale isn't set properly

### DIFF
--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -51,8 +51,10 @@ i18nOpts = {
 i18n.configure i18nOpts
 #
 # force initialize
-if i18n.getLocales().includes viewstate.language
-    i18n.setLocale(viewstate.language)
+if not i18n.getLocales().includes viewstate.language
+    viewstate.language = i18nOpts.defaultLocale
+
+i18n.setLocale(viewstate.language)
 #
 ipc.send 'seti18n', i18nOpts, viewstate.language
 

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -404,7 +404,7 @@ handle 'setspellchecklanguage', (language) ->
 # Change language in YakYak
 #
 handle 'changelanguage', (language) ->
-    if i18n.getLocales().includes viewstate.language
+    if i18n.getLocales().includes language
         ipc.send 'seti18n', null, language
         viewstate.setLanguage(language)
 


### PR DESCRIPTION
This fixes an issue where yakyak won't start properly if the locale/language in the viewstate isn't set up properly (for example, if modifying files manually). It's not super interesting, but it's something I found while testing something else, so I thought it'd be good to get it fixed.