### PR TITLE
Fix deployed filename being wrong when generating rpm

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -381,10 +381,9 @@ archOpts.forEach (arch) ->
             else
                 suffix = target
 
-            if target == 'pacman'
-                packageName = json.name + '-VERSION-linux-' + archNameSuffix + '-pacman.' + suffix
-            else
-                packageName = json.name + '-VERSION-linux-' + archNameSuffix + '.' + suffix
+            packageName = json.name + '-' + json.version + '-linux-' + archNameSuffix +
+                (if target is 'pacman' then '-pacman.' else '.') + suffix
+
             iconArgs = [16, 32, 48, 128, 256, 512].map (size) ->
                 if size < 100
                     src = "0#{size}"


### PR DESCRIPTION
This fixes an issue where if the version number contains a hyphen the deployed rpm filename will be wrong because fpm replaces any hyphens with underscores due to the rpm format not allowing them. It simply does this by using the version specified in the json for the filename rather than using the version number from fpm.