### PR TITLE
IPC fixes

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -208,8 +208,8 @@ app.on 'ready', ->
     ipc.on 'mainwindow:toggle', ->
         if mainWindow.isVisible() then mainWindow.hide() else mainWindow.show()
 
-    ipc.on "mainwindow:isvisibleandfocused", (event) ->
-        event.returnValue = mainWindow.isVisible() and mainWindow.isFocused()
+    ipc.handle "mainwindow:isvisibleandfocused", () ->
+        return mainWindow.isVisible() and mainWindow.isFocused()
 
     ipc.on 'mainwindow:flashframe', -> mainWindow.flashFrame(true)
     ipc.on 'mainwindow:minimize', -> mainWindow.minimize()

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -187,8 +187,8 @@ app.on 'ready', ->
     # away if we must do auth.
     loadAppWindow()
 
-    ipc.on 'app:version', (event) ->
-        event.returnValue = app.getVersion()
+    ipc.handle 'app:version', () ->
+        return app.getVersion()
 
     ipc.on 'download:saveas', (event, url) ->
         try

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -432,11 +432,11 @@ app.on 'ready', ->
           tray.setImage iconpath unless tray.currentImage == iconpath
         else
           tray = new Tray iconpath
+          tray.on 'click', (ev) -> ipcsend 'menuaction', 'togglewindow'
 
         tray.currentImage = iconpath
 
         tray.setToolTip toolTip
-        tray.on 'click', (ev) -> ipcsend 'menuaction', 'togglewindow'
 
         if menu
             # build functions that cannot be sent via ipc

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -243,8 +243,8 @@ app.on 'ready', ->
 
     ipc.handle 'screen:getalldisplays', () -> return screen.getAllDisplays()
 
-    ipc.on 'spellcheck:availablelanguages', (event) ->
-        event.returnValue = mainWindow.webContents.session.availableSpellCheckerLanguages
+    ipc.handle 'spellcheck:availablelanguages', () ->
+        return mainWindow.webContents.session.availableSpellCheckerLanguages
 
     ipc.on 'spellcheck:setlanguage', (event, lang) ->
         if lang is 'none'

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -199,7 +199,7 @@ app.on 'ready', ->
     ipc.handle 'global:forceclose', () ->
         return global.forceClose
 
-    ipc.on 'mainwindow:getsize', (event) -> event.returnValue = mainWindow.getSize()
+    ipc.handle 'mainwindow:getsize', () -> return mainWindow.getSize()
     ipc.on 'mainwindow:setsize', (event, size) -> mainWindow.setSize size...
     ipc.on 'mainwindow:setposition', (event, x, y) -> mainWindow.setPosition(x, y)
     ipc.on 'mainwindow:close', -> mainWindow.close()
@@ -241,8 +241,7 @@ app.on 'ready', ->
     ipc.on 'menu.applicationmenu:popup', ->
         Menu.getApplicationMenu().popup({})
 
-    ipc.on 'screen:getalldisplays', (event) ->
-        event.returnValue = screen.getAllDisplays()
+    ipc.handle 'screen:getalldisplays', () -> return screen.getAllDisplays()
 
     ipc.on 'spellcheck:availablelanguages', (event) ->
         event.returnValue = mainWindow.webContents.session.availableSpellCheckerLanguages

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -196,8 +196,8 @@ app.on 'ready', ->
         catch err
             console.log 'Possible problem with saving image. ', err
 
-    ipc.on 'global:forceclose', (event) ->
-        event.returnValue = global.forceClose
+    ipc.handle 'global:forceclose', () ->
+        return global.forceClose
 
     ipc.on 'mainwindow:getsize', (event) -> event.returnValue = mainWindow.getSize()
     ipc.on 'mainwindow:setsize', (event, size) -> mainWindow.setSize size...

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -170,7 +170,7 @@ handle 'togglehidedockicon', ->
 
 handle 'show-about', ->
     viewstate.setState viewstate.STATE_ABOUT
-    updated 'viewstate'
+    viewstate.updateView()
 
 handle 'hideWindow', ->
     ipc.send 'mainwindow:hide'

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -155,20 +155,19 @@ module.exports = exp = {
             later -> action 'updatewatermark'
 
     setSize: (size) ->
+        return if @state == STATES.STATE_STARTUP
         localStorage.size = JSON.stringify(size)
         @size = size
         # @updateView()
 
     setPosition: (pos) ->
-        if @state == STATES.STATE_STARTUP
-            return
-
+        return if @state == STATES.STATE_STARTUP
         localStorage.pos = JSON.stringify(pos)
         @pos = pos
         # @updateView()
 
     setLeftSize: (size) ->
-        return if @leftSize == size or size < 180
+        return if @state == STATES.STATE_STARTUP or @leftSize == size or size < 180
         @leftSize = localStorage.leftSize = size
         @updateView()
 

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -348,7 +348,7 @@ module.exports = exp = {
 
         # the awaits above means this function will be async,
         # so we can't trigger the 'updated' action directly from here
-        action 'viewstate:updated'
+        action 'viewstate_updated'
 }
 
 merge exp, STATES

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -160,6 +160,9 @@ module.exports = exp = {
         # @updateView()
 
     setPosition: (pos) ->
+        if @state == STATES.STATE_STARTUP
+            return
+
         localStorage.pos = JSON.stringify(pos)
         @pos = pos
         # @updateView()

--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -54,6 +54,8 @@ module.exports = exp = {
     # contacts are loaded
     loadedContacts: false
     openOnSystemStartup: false
+    allDisplays: {}
+    winSize: {}
 
     setUseSystemDateFormat: (val) ->
         @useSystemDateFormat = val
@@ -63,7 +65,7 @@ module.exports = exp = {
     setContacts: (state) ->
         return if state == @loadedContacts
         @loadedContacts = state
-        updated 'viewstate'
+        @updateView()
 
     setState: (state) ->
         return if @state == state
@@ -72,13 +74,13 @@ module.exports = exp = {
             # set a first active timestamp to avoid requesting
             # syncallnewevents on startup
             require('./connection').setLastActive(Date.now(), true)
-        updated 'viewstate'
+        @updateView()
 
     setSpellCheckLanguage: (language) ->
         return if @language == language
         ipc.send 'spellcheck:setlanguage', language
         @spellcheckLanguage = localStorage.spellcheckLanguage = language
-        updated 'viewstate'
+        @updateView()
 
     setLanguage: (language) ->
         return if @language == language
@@ -113,7 +115,7 @@ module.exports = exp = {
         @switchInput(conv_id)
         @selectedConv = localStorage.selectedConv = conv_id
         @setLastKeyDown 0
-        updated 'viewstate'
+        @updateView()
         updated 'switchConv'
 
     selectNextConv: (offset = 1) ->
@@ -134,7 +136,7 @@ module.exports = exp = {
     updateAtTop: (attop) ->
         return if @attop == attop
         @attop = attop
-        updated 'viewstate'
+        @updateView()
 
     updateAtBottom: (atbottom) ->
         return if @atbottom == atbottom
@@ -155,17 +157,17 @@ module.exports = exp = {
     setSize: (size) ->
         localStorage.size = JSON.stringify(size)
         @size = size
-        # updated 'viewstate'
+        # @updateView()
 
     setPosition: (pos) ->
         localStorage.pos = JSON.stringify(pos)
         @pos = pos
-        # updated 'viewstate'
+        # @updateView()
 
     setLeftSize: (size) ->
         return if @leftSize == size or size < 180
         @leftSize = localStorage.leftSize = size
-        updated 'viewstate'
+        @updateView()
 
     setZoom: (zoom) ->
         @zoom = localStorage.zoom = document.body.style.zoom = zoom
@@ -173,11 +175,11 @@ module.exports = exp = {
 
     setLoggedin: (val) ->
         @loggedin = val
-        updated 'viewstate'
+        @updateView()
 
     setShowSeenStatus: (val) ->
         @showseenstatus = localStorage.showseenstatus = !!val
-        updated 'viewstate'
+        @updateView()
 
     setLastKeyDown: do ->
         {TYPING, PAUSED, STOPPED} = Client.TypingStatus
@@ -209,74 +211,74 @@ module.exports = exp = {
         @showConvMin = localStorage.showConvMin = doshow
         if doshow
             this.setShowConvThumbs(true)
-        updated 'viewstate'
+        @updateView()
 
     setShowConvThumbs: (doshow) ->
         return if @showConvThumbs == doshow
         @showConvThumbs = localStorage.showConvThumbs = doshow
         unless doshow
             this.setShowConvMin(false)
-        updated 'viewstate'
+        @updateView()
 
     setShowAnimatedThumbs: (doshow) ->
         return if @showAnimatedThumbs == doshow
         @showAnimatedThumbs = localStorage.showAnimatedThumbs = doshow
-        updated 'viewstate'
+        @updateView()
 
     setShowConvTime: (doshow) ->
         return if @showConvTime == doshow
         @showConvTime = localStorage.showConvTime = doshow
-        updated 'viewstate'
+        @updateView()
 
     setShowConvLast: (doshow) ->
         return if @showConvLast == doshow
         @showConvLast = localStorage.showConvLast = doshow
-        updated 'viewstate'
+        @updateView()
 
     setShowPopUpNotifications: (doshow) ->
         return if @showPopUpNotifications == doshow
         @showPopUpNotifications = localStorage.showPopUpNotifications = doshow
-        updated 'viewstate'
+        @updateView()
 
     setShowMessageInNotification: (doshow) ->
         return if @showMessageInNotification == doshow
         @showMessageInNotification = localStorage.showMessageInNotification = doshow
-        updated 'viewstate'
+        @updateView()
 
     setShowUsernameInNotification: (doshow) ->
         return if @showUsernameInNotification == doshow
         @showUsernameInNotification = localStorage.showUsernameInNotification = doshow
-        updated 'viewstate'
+        @updateView()
 
     setForceCustomSound: (doshow) ->
         return if localStorage.forceCustomSound == doshow
         @forceCustomSound = localStorage.forceCustomSound = doshow
-        updated 'viewstate'
+        @updateView()
 
     setShowIconNotification: (doshow) ->
         return if localStorage.showIconNotification == doshow
         @showIconNotification = localStorage.showIconNotification = doshow
-        updated 'viewstate'
+        @updateView()
 
     setMuteSoundNotification: (doshow) ->
         return if localStorage.muteSoundNotification == doshow
         @muteSoundNotification = localStorage.muteSoundNotification = doshow
-        updated 'viewstate'
+        @updateView()
 
     setConvertEmoji: (doshow) ->
         return if @convertEmoji == doshow
         @convertEmoji = localStorage.convertEmoji = doshow
-        updated 'viewstate'
+        @updateView()
 
     setSuggestEmoji: (doshow) ->
         return if @suggestEmoji == doshow
         @suggestEmoji = localStorage.suggestEmoji = doshow
-        updated 'viewstate'
+        @updateView()
 
     setshowImagePreview: (doshow) ->
         return if @showImagePreview == doshow
         @showImagePreview = localStorage.showImagePreview = doshow
-        updated 'viewstate'
+        @updateView()
 
     setColorScheme: (colorscheme) ->
         @colorScheme = localStorage.colorScheme = colorscheme
@@ -293,11 +295,11 @@ module.exports = exp = {
 
     setEscapeClearsInput: (value) ->
         @escapeClearsInput = localStorage.escapeClearsInput = value
-        updated 'viewstate'
+        @updateView()
 
     setColorblind: (value) ->
         @colorblind = localStorage.colorblind = value
-        updated 'viewstate'
+        @updateView()
 
     setShowTray: (value) ->
         @showtray = localStorage.showtray = value
@@ -306,22 +308,22 @@ module.exports = exp = {
             @setCloseToTray(false)
             @setStartMinimizedToTray(false)
         else
-            updated 'viewstate'
+            @updateView()
 
     setHideDockIcon: (value) ->
         @hidedockicon = localStorage.hidedockicon = value
-        updated 'viewstate'
+        @updateView()
 
     setStartMinimizedToTray: (value) ->
         @startminimizedtotray = localStorage.startminimizedtotray = value
-        updated 'viewstate'
+        @updateView()
 
     setShowDockIconOnce: (value) ->
         @showDockIconOnce = value
 
     setCloseToTray: (value) ->
         @closetotray = localStorage.closetotray = !!value
-        updated 'viewstate'
+        @updateView()
 
     setOpenOnSystemStartup: (open) ->
         return if @openOnSystemStartup == open
@@ -333,12 +335,20 @@ module.exports = exp = {
 
         @openOnSystemStartup = open
 
-        updated 'viewstate'
+        @updateView()
 
     initOpenOnSystemStartup: (isEnabled) ->
         @openOnSystemStartup = isEnabled
 
-        updated 'viewstate'
+        @updateView()
+
+    updateView: () ->
+        @allDisplays = await ipc.invoke 'screen:getalldisplays'
+        @winSize = await ipc.invoke 'mainwindow:getsize'
+
+        # the awaits above means this function will be async,
+        # so we can't trigger the 'updated' action directly from here
+        action 'viewstate:updated'
 }
 
 merge exp, STATES

--- a/src/ui/version.coffee
+++ b/src/ui/version.coffee
@@ -11,12 +11,13 @@ versionToInt = (version) ->
     version = (micro * Math.pow(10,4)) + (minor * Math.pow(10,8)) + (major * Math.pow(10,12))
 
 check = ()->
+    window.localStorage.localVersion = await ipc.invoke "app:version"
     got(options.url)
         .then (res) ->
             body = JSON.parse res.body
             tag = body.tag_name
-            releasedVersion = tag?.substr(1) # remove first "v" char
-            localVersion    = ipc.sendSync "app:version"
+            releasedVersion   = tag?.substr(1) # remove first "v" char
+            localVersion      = window.localStorage.localVersion
             versionAdvertised = window.localStorage.versionAdvertised or null
             if releasedVersion? && localVersion?
                 higherVersionAvailable = versionToInt(releasedVersion) > versionToInt(localVersion)

--- a/src/ui/views/about.coffee
+++ b/src/ui/views/about.coffee
@@ -7,7 +7,7 @@ i18n = require 'i18n'
 module.exports = view (models) ->
     #
     # decide if should update
-    localVersion    = ipc.sendSync "app:version"
+    localVersion    = window.localStorage.localVersion
     releasedVersion = window.localStorage.versionAdvertised
     shouldUpdate    = releasedVersion? && localVersion? &&
                       versionToInt(releasedVersion) > versionToInt(localVersion)

--- a/src/ui/views/contextmenu.coffee
+++ b/src/ui/views/contextmenu.coffee
@@ -4,7 +4,11 @@ clipboard     = require('electron').clipboard
 
 {isContentPasteable} = require '../util'
 
-availableLanguages = ipc.sendSync 'spellcheck:availablelanguages'
+ipc.invoke('spellcheck:availablelanguages')
+    .then (res) ->
+        window.availableLanguages = res
+    .catch (error) ->
+        console.error(error)
 
 templateContext = (params, viewstate) ->
     #
@@ -22,7 +26,7 @@ templateContext = (params, viewstate) ->
     else
         i18n.__('menu.edit.spell_check.title:Spellcheck') + ': ' + spellcheckLanguage
 
-    langMenu = availableLanguages.map (el) ->
+    langMenu = (window.availableLanguages ? []).map (el) ->
         {
             label: el,
             action: {name: 'setspellchecklanguage', params: [el]}

--- a/src/ui/views/controller.coffee
+++ b/src/ui/views/controller.coffee
@@ -45,8 +45,10 @@ handle 'update:connection', do ->
 #     \_/ |_|\___| \_/\_/ |___/\__\__,_|\__\___|
 #
 #
-handle 'update:viewstate', ->
+handle 'viewstate:updated', ->
+    updated 'viewstate'
 
+handle 'update:viewstate', ->
     setLeftSize = (left) ->
         document.querySelector('.left').style.width = left + 'px'
         document.querySelector('.leftresize').style.left = (left - 2) + 'px'
@@ -87,9 +89,9 @@ handle 'update:viewstate', ->
             xWindowPos = viewstate.pos[0]
             yWindowPos = viewstate.pos[1]
             # window size to be used in rounding the position, i.e. avoiding partial offscreen
-            winSize = ipc.sendSync 'mainwindow:getsize'
+            winSize = viewstate.winSize
             # iterate on all displays to see if the desired position is valid
-            for screen in ipc.sendSync 'screen:getalldisplays'
+            for screen in viewstate.allDisplays
                 # get bounds of each display
                 {width, height} = screen.workAreaSize
                 {x, y} = screen.workArea

--- a/src/ui/views/controller.coffee
+++ b/src/ui/views/controller.coffee
@@ -45,7 +45,7 @@ handle 'update:connection', do ->
 #     \_/ |_|\___| \_/\_/ |___/\__\__,_|\__\___|
 #
 #
-handle 'viewstate:updated', ->
+handle 'viewstate_updated', ->
     updated 'viewstate'
 
 handle 'update:viewstate', ->

--- a/src/ui/views/messages.coffee
+++ b/src/ui/views/messages.coffee
@@ -405,6 +405,7 @@ preloadTweet = (href) ->
             frag = document.createElement 'div'
             frag.innerHTML = html
             container = frag.querySelector '[data-associated-tweet-id]'
+            return if not container?
             textNode = container.querySelector ('.tweet-text')
             image = container.querySelector ('[data-image-url]')
             preload_cache[href].text = textNode.textContent

--- a/src/ui/views/notifications.coffee
+++ b/src/ui/views/notifications.coffee
@@ -22,7 +22,7 @@ module.exports = (models) ->
     {conv, notify, entity, viewstate} = models
     tonot = notify.popToNotify()
 
-    visibleFocused = ipc.sendSync 'mainwindow:isvisibleandfocused'
+    visibleFocused = await ipc.invoke 'mainwindow:isvisibleandfocused'
     quietIf = (c, chat_id) -> visibleFocused or conv.isQuiet(c) or entity.isSelf(chat_id)
 
     tonot.forEach (msg) ->


### PR DESCRIPTION
This PR basically converts all ipc sendSync calls to use the asynchronous invoke instead. The reason for this is that sendSync blocks the entire renderer process which can lead to problems. I've also noticed in my testing that sendSync can sometimes take a second or two to return, meaning some things will take longer than expected.

One side effect of using the invoke method is that we use await to wait for the response, but this causes the whole function to become async, and the code isn't always optimal to support this.
An example of this is the viewstate that needs to use some things from the main thread, but the update trifl code doesn't like being run in an async function. I solved this by retrieving the stuff and then calling an action that will call the updated action (this is necessary because updated can only be called from an action, and due to the function being async that won't be the case). 