### PR TITLE
Fix travis failing due to changes with fpm

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -407,6 +407,7 @@ archOpts.forEach (arch) ->
                 '--package', "./dist/#{packageName}"
                 '--after-install', './resources/linux/after-install.sh'
                 '--after-remove', './resources/linux/after-remove.sh'
+                '--pacman-compression', 'gz'
                 "./dist/#{json.name}-linux-#{arch}/.=/opt/#{json.name}"
                 "./resources/linux/app.desktop=/usr/share/applications/#{json.name}.desktop"
             ].concat iconArgs


### PR DESCRIPTION
A recent change to fpm switched to using zstd compression by default which travis doesn't seem to support. We now use gz instead. 