### PR TITLE
Use the new getvideoinformation from hangupsjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5993,7 +5993,7 @@
       }
     },
     "node_modules/hangupsjs": {
-      "resolved": "git+ssh://git@github.com/yakyak/hangupsjs.git#551dd17f82aa56f6e8b74ddd2a8dae852fc7bb1e",
+      "resolved": "git+ssh://git@github.com/yakyak/hangupsjs.git#71d515e6422e1bfe926100fb783bdcc75c154c4c",
       "dependencies": {
         "bog": "^1.0.0",
         "fnuc": "0.0.15",
@@ -18657,7 +18657,7 @@
       }
     },
     "hangupsjs": {
-      "version": "git+ssh://git@github.com/yakyak/hangupsjs.git#551dd17f82aa56f6e8b74ddd2a8dae852fc7bb1e",
+      "version": "git+ssh://git@github.com/yakyak/hangupsjs.git#71d515e6422e1bfe926100fb783bdcc75c154c4c",
       "from": "hangupsjs@yakyak/hangupsjs",
       "requires": {
         "bog": "^1.0.0",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -499,6 +499,10 @@ app.on 'ready', ->
             client.sendchatmessage conv_id, null, image_id, null, client_generated_id, delivery_medium
     , true
 
+    ipc.on 'getvideoinformation', seqreq (ev, conv_id, event_id, user_id, photo_id) ->
+        client.getvideoinformation(user_id, photo_id).then (body) ->
+            ipcsend 'getvideoinformation:result', conv_id, event_id, photo_id, body
+
     # we want to upload. in the order specified, with retry
     ipc.on 'uploadclipboardimage', seqreq (ev, spec) ->
         {pngData, conv_id, client_generated_id} = spec

--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -174,6 +174,9 @@ ipc.on 'menuaction', (ev, name, p) ->
 ipc.on 'getentity:result', (ev, r, data) ->
     action 'addentities', r.entities, data?.add_to_conv
 
+ipc.on 'getvideoinformation:result', (ev, conv_id, event_id, photo_id, result) ->
+    action 'videoinformation', conv_id, event_id, photo_id, result
+
 ipc.on 'resize', (ev, dim) -> action 'resize', dim
 
 ipc.on 'move', (ev, pos)  -> action 'move', pos

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -292,6 +292,12 @@ handle 'uploadimage', (files) ->
     # clear value for upload image input
     document.getElementById('attachFile').value = ''
 
+handle 'getvideoinformation', (conv_id, event_id, user_id, photo_id) ->
+    ipc.send 'getvideoinformation', conv_id, event_id, user_id, photo_id
+
+handle 'videoinformation', (conv_id, event_id, photo_id, result) ->
+    conv.updateVideoInformation conv_id, event_id, photo_id, result
+
 handle 'onpasteimage', ->
     element = document.getElementById 'preview-img'
     element.src = clipboard.readImage().toDataURL()

--- a/src/ui/models/conv.coffee
+++ b/src/ui/models/conv.coffee
@@ -131,6 +131,30 @@ addWatermark = (ev) ->
     unreadTotal()
     updated 'conv'
 
+updateVideoInformation = (conv_id, event_id, photo_id, result) ->
+    console.error('updateVideoInformation', result)
+    thumb = result.videoItem?.thumbnail?.url
+    url = null
+    res = 0
+    for stream in result.videoItem?.videoStream ? []
+        continue if stream.width * stream.height < res
+        res = stream.width * stream.height
+        url = stream.playUrl
+
+    conv = lookup[conv_id]
+    if conv? and conv.event?
+        cpos = findByEventId conv, event_id
+        if cpos
+            for e in conv.event[cpos].chat_message.message_content.attachment ? []
+                plus_photo = e.embed_item.plus_photo
+                if plus_photo.data.photo_id is photo_id
+                    plus_photo.videoinformation = {
+                        thumb: thumb,
+                        url: url
+                    }
+
+    updated 'conv'
+
 uniqfn = (as, fn) -> bs = as.map fn; as.filter (e, i) -> bs.indexOf(bs[i]) == i
 
 sortby = (conv) -> conv?.self_conversation_state?.sort_timestamp ? 0
@@ -288,6 +312,7 @@ funcs =
     pruneTyping: pruneTyping
     unreadTotal: unreadTotal
     findLastReadEventsByUser: findLastReadEventsByUser
+    updateVideoInformation: updateVideoInformation
 
     setNotificationLevel: (conv_id, level) ->
         return unless c = lookup[conv_id]


### PR DESCRIPTION
We can now properly get public urls for video attachments, so use this new function. This also updates images to use the proper thumbnail and public url.