### PR TITLE
Update hangupsjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4991,8 +4991,8 @@
       }
     },
     "hangupsjs": {
-      "version": "github:yakyak/hangupsjs#551dd17f82aa56f6e8b74ddd2a8dae852fc7bb1e",
-      "from": "github:yakyak/hangupsjs#coffeescriptv2",
+      "version": "github:yakyak/hangupsjs#f74c672764cd27f01c36f0c9127ed9b983cd2398",
+      "from": "github:yakyak/hangupsjs#v1.5-stable",
       "requires": {
         "bog": "^1.0.0",
         "fnuc": "0.0.15",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "electron-installer-debian": "^3.1.0",
     "electron-installer-flatpak": "^0.6.0",
     "got": "^11.8.0",
-    "hangupsjs": "github:yakyak/hangupsjs#coffeescriptv2",
+    "hangupsjs": "github:yakyak/hangupsjs#v1.5-stable",
     "i18n": "^0.13.2",
     "mime-types": "^2.1.27",
     "moment": "^2.28.0",


### PR DESCRIPTION
This fixes an issue where the private token could no longer be fetched.