### PR TITLE
Workaround issues when upgrading from v1.5.9 or older

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yakyak",
-  "version": "1.5.11.1",
+  "version": "1.5.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yakyak",
-  "version": "1.5.11.1",
+  "version": "1.5.11.2",
   "description": "Chat client for Google Hangouts",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
This issue is caused by 1.5.10 introducing asar, but if you upgraded from v1.5.9 the app directory would remain, and electron prefers to use the directory rather than the asar file. This meant that it would use the old app files which caused a whole bunch of issues.
The PR works around this by creating an empty package.json file in the resources/app directory, effectively overwriting the old one and causing electron to use the app.asar file instead.