### PR TITLE
Load notification file from data

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -34,6 +34,7 @@ tray = null # set global tray
 
 # Path for configuration
 userData = path.normalize(app.getPath('userData'))
+global.USERDATA_DIR = userData
 
 # makedir if it doesn't exist
 fs.mkdirSync(userData) if not fs.existsSync userData
@@ -190,6 +191,9 @@ app.on 'ready', ->
 
     ipc.handle 'app:version', () ->
         return app.getVersion()
+
+    ipc.handle 'app:getpath', (event, type) ->
+        return path.normalize(app.getPath(type))
 
     ipc.on 'download:saveas', (event, url) ->
         try

--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -17,6 +17,11 @@ notr.defineStack 'def', 'body', {top:'3px', right:'15px'}
 # init trifl dispatcher
 dispatcher = require './dispatcher'
 
+ipc.invoke('app:getpath', 'userData').then((res) ->
+    console.error 'userData', res
+    global.USERDATA_DIR = res
+)
+
 window.onerror = (msg, url, lineNo, columnNo, error) ->
     hash = {msg, url, lineNo, columnNo, error}
     ipc.send 'errorInWindow', hash

--- a/src/ui/views/notifications.coffee
+++ b/src/ui/views/notifications.coffee
@@ -105,14 +105,10 @@ module.exports = (models) ->
             #  and mute option is not set
             if (!notifierSupportsSound || viewstate.forceCustomSound) && !viewstate.muteSoundNotification && audioEl.paused
                 dataFile = path.join USERDATA_DIR, 'media', 'new_message.ogg'
-                isCustom = audioEl.custom != undefined && audioEl.custom == 1
-                if !isCustom && fs.existsSync(dataFile)
-                    audioEl.custom = 1
+                if fs.existsSync(dataFile)
                     audioEl.src = dataFile
-                    audioEl.load()
-                else if isCustom
+                else
                     audioEl.src = path.join YAKYAK_ROOT_DIR, '..', 'media', 'new_message.ogg'
-                    audioEl.load()
 
                 audioEl.play()
         # if not mainWindow.isVisible()

--- a/src/ui/views/notifications.coffee
+++ b/src/ui/views/notifications.coffee
@@ -3,6 +3,8 @@ notifier = require 'node-notifier'
 shell    = require('electron').shell
 path     = require 'path'
 i18n     = require 'i18n'
+fs       = require 'fs'
+app = require('electron').app
 
 {nameof, getProxiedName, fixlink, notificationCenterSupportsSound} = require '../util'
 
@@ -16,7 +18,6 @@ audioFile = path.join YAKYAK_ROOT_DIR, '..', 'media',
 'new_message.ogg'
 audioEl = new Audio(audioFile)
 audioEl.volume = .4
-
 
 module.exports = (models) ->
     {conv, notify, entity, viewstate} = models
@@ -103,6 +104,16 @@ module.exports = (models) ->
             #  and notifier does not support sound or force custom sound is set
             #  and mute option is not set
             if (!notifierSupportsSound || viewstate.forceCustomSound) && !viewstate.muteSoundNotification && audioEl.paused
+                dataFile = path.join USERDATA_DIR, 'media', 'new_message.ogg'
+                isCustom = audioEl.custom != undefined && audioEl.custom == 1
+                if !isCustom && fs.existsSync(dataFile)
+                    audioEl.custom = 1
+                    audioEl.src = dataFile
+                    audioEl.load()
+                else if isCustom
+                    audioEl.src = path.join YAKYAK_ROOT_DIR, '..', 'media', 'new_message.ogg'
+                    audioEl.load()
+
                 audioEl.play()
         # if not mainWindow.isVisible()
         #    mainWindow.showInactive()


### PR DESCRIPTION
This simply allows you to use a notification ogg file from the user data directory, rather than using the built-in one. Useful for systems that don't allow you to override the notification sound manually.