### PR TITLE
Fix exceptions, fix deprecation, fix potential bad crash, use current timestamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,9 @@
       "version": "1.5.12-beta",
       "license": "MIT",
       "dependencies": {
-        "@malept/electron-installer-flatpak": "^0.11.2",
         "auto-launch": "^5.0.5",
         "autosize": "^4.0.2",
         "bog": "^1.0.0",
-        "electron-installer-debian": "^3.1.0",
         "got": "^11.8.1",
         "hangupsjs": "github:yakyak/hangupsjs",
         "i18n": "^0.13.2",
@@ -77,8 +75,6 @@
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
         "fs-extra": "^8.1.0",
-        "global-agent": "^2.0.2",
-        "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
         "progress": "^2.0.3",
         "sanitize-filename": "^1.6.2",
@@ -1854,7 +1850,6 @@
       "integrity": "sha512-k7zd+KoR+n8pl71PvgElcoKHrVNiSXtw7odKbyNpmgKe7EGRF9Pnu3uLOukD37EvavKwVFxOUpqXTIZC5B5Pmw==",
       "devOptional": true,
       "dependencies": {
-        "@types/glob": "^7.1.1",
         "chromium-pickle-js": "^0.2.0",
         "commander": "^5.0.0",
         "glob": "^7.1.6",
@@ -2576,7 +2571,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -3742,7 +3736,6 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -7249,12 +7242,7 @@
       "integrity": "sha512-+1V2PCMFkL+OIj2/HrtrvZw0BC0sYLMICJfbQjuj/K8CEnlrFX6R5cKKgzzttsZDHyxQNL1jqMREjKN3ja/E3Q==",
       "dev": true,
       "dependencies": {
-        "errno": "^0.1.1",
         "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "make-dir": "^2.1.0",
-        "mime": "^1.4.1",
-        "native-request": "^1.0.5",
         "source-map": "~0.6.0",
         "tslib": "^1.10.0"
       },
@@ -8232,7 +8220,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -12805,7 +12792,6 @@
       "dev": true,
       "dependencies": {
         "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
         "yargs": "~3.10.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -61,11 +61,9 @@
     ]
   },
   "dependencies": {
-    "@malept/electron-installer-flatpak": "^0.11.2",
     "auto-launch": "^5.0.5",
     "autosize": "^4.0.2",
     "bog": "^1.0.0",
-    "electron-installer-debian": "^3.1.0",
     "got": "^11.8.1",
     "hangupsjs": "github:yakyak/hangupsjs",
     "i18n": "^0.13.2",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -280,19 +280,20 @@ app.on 'ready', ->
     #
     # Handle uncaught exceptions from the main process
     process.on 'uncaughtException', (msg) ->
-        ipcsend 'expcetioninmain', msg
         #
-        console.log "Error on main process:\n#{msg}\n" +
+        ipcsend 'exceptioninmain', JSON.stringify(msg)
+        console.error "Error on main process:\n#{msg}\n" +
             "--- End of error message. More details:\n", msg
 
     #
     #
     # Handle crashes on the main window and show in console
-    mainWindow.webContents.on 'crashed', (msg) ->
-        console.log 'Crash event on main window!', msg
-        ipc.send 'expcetioninmain', {
+    mainWindow.webContents.on 'render-process-gone', (event, details) ->
+        console.log 'Crash event on main window!', 'event', event, 'details', details
+        ipcsend 'exceptioninmain', {
             msg: 'Detected a crash event on the main window.'
-            event: msg
+            event: JSON.stringify(event)
+            details: details
         }
 
     # short hand
@@ -311,6 +312,7 @@ app.on 'ready', ->
             webPreferences: {
                 nodeIntegration: false
                 javascript: true
+                contextIsolation: true
             }
         }
         loginWindow.webContents.openDevTools() if debug
@@ -413,7 +415,7 @@ app.on 'ready', ->
 
     ipc.on 'errorInWindow', (ev, error, winName = 'YakYak') ->
         mainWindow.show() unless global.isReadyToShow
-        ipcsend 'expcetioninmain', error
+        ipcsend 'exceptioninmain', error
         console.log "Error on #{winName} window:\n", error, "\n--- End of error message in #{winName} window."
 
 

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -281,9 +281,10 @@ app.on 'ready', ->
     # Handle uncaught exceptions from the main process
     process.on 'uncaughtException', (msg) ->
         #
-        ipcsend 'exceptioninmain', JSON.stringify(msg)
         console.error "Error on main process:\n#{msg}\n" +
             "--- End of error message. More details:\n", msg
+
+        ipcsend 'exceptioninmain', JSON.stringify(msg)
 
     #
     #

--- a/src/ui/app.coffee
+++ b/src/ui/app.coffee
@@ -103,7 +103,6 @@ ipc.on 'ready-to-show', () ->
     ipc.on 'mainwindow.focus', () ->
         if viewstate.state == viewstate.STATE_NORMAL
             # focus on webContents
-            ipc.send 'mainwindow.webcontents:focus'
             el = window.document.getElementById('message-input')
             # focus on specific element
             el?.focus()
@@ -152,7 +151,7 @@ if process.platform == 'win32'
 # Get information on exceptions in main process
 #  - Exceptions that were caught
 #  - Window crashes
-ipc.on 'expcetioninmain', (error) ->
+ipc.on 'exceptioninmain', (error) ->
     console.error (msg = "Possible fatal error on main process" +
         ", YakYak could stop working as expected."), error
     notr msg, {stay: 0}

--- a/src/ui/models/entity.coffee
+++ b/src/ui/models/entity.coffee
@@ -69,7 +69,7 @@ funcs =
     setLastSeen: (id, lastseen) ->
         return needEntity(id) if not lookup[id]
         lookup[id].lastseen = lastseen
-        cutoff = lookup.self.lastseen - (60 * 15)
+        cutoff = Date.now() / 1000 - (60 * 15)
         if lastseen > cutoff
             lookup[id].presence = true
 
@@ -78,18 +78,14 @@ funcs =
     isSelf: (chat_id) -> return !!lookup.self and lookup[chat_id] == lookup.self
 
     updatePresence: ->
-        if lookup.self?.lastseen?
-            changed = false
-            cutoff = lookup.self.lastseen - (60 * 15)
-            for k, v of lookup when v.presence and not @isSelf(k)
-                if !v.lastseen?
-                    v.lastseen = lookup.self.lastseen
+        changed = false
+        cutoff = Math.floor(Date.now() / 1000) - (60 * 15)
+        for k, v of lookup when v?.presence? and v.presence and v.lastseen? and not @isSelf(k)
+            if v.lastseen <= cutoff
+                v.presence = false
+                changed = true
 
-                if v.lastseen <= cutoff
-                    v.presence = false
-                    changed = true
-
-            updated 'entity' if changed
+        updated 'entity' if changed
 
     _reset: ->
         delete lookup[k] for k, v of lookup when typeof v == 'object'


### PR DESCRIPTION
This has some changes to how exceptions are handled, as well as a few other fixes.

* The crashed event has been deprecated for a while, and is replaced with render-process-gone.
* Fix spelling of exceptioninmain.
* Use contextIsolation on the login window, to ensure the remote page can't access electron/nodejs functionality.
* Fix potential bad crash when closing due to the window focus event being sent after the window is gone.
* Use current timestamp for entity presence calculation, rather than relying on the self timestamp.