### PR TITLE
Update hangupsjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6103,7 +6103,7 @@
       }
     },
     "node_modules/hangupsjs": {
-      "resolved": "git+ssh://git@github.com/yakyak/hangupsjs.git#cb96a747dd0d523b3e67a241e8909567fe5e674c",
+      "resolved": "git+ssh://git@github.com/yakyak/hangupsjs.git#152acbbad5b141b44e708a85b7b0b74c6a73b233",
       "dependencies": {
         "bog": "^1.0.0",
         "fnuc": "0.0.15",
@@ -18703,7 +18703,7 @@
       }
     },
     "hangupsjs": {
-      "version": "git+ssh://git@github.com/yakyak/hangupsjs.git#cb96a747dd0d523b3e67a241e8909567fe5e674c",
+      "version": "git+ssh://git@github.com/yakyak/hangupsjs.git#152acbbad5b141b44e708a85b7b0b74c6a73b233",
       "from": "hangupsjs@github:yakyak/hangupsjs",
       "requires": {
         "bog": "^1.0.0",


### PR DESCRIPTION
This fixes an issue with not being able to login anymore due to a regex issue in the private token fetching.