### PR TITLE
Add workaround for google chat attachments

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -2,6 +2,7 @@ Client    = require 'hangupsjs'
 Q         = require 'q'
 login     = require './login'
 ipc       = require('electron').ipcMain
+shell     = require('electron').shell
 fs        = require 'fs'
 path      = require 'path'
 tmp       = require 'tmp'
@@ -536,6 +537,12 @@ app.on 'ready', ->
     ipc.on 'getvideoinformation', seqreq (ev, conv_id, event_id, user_id, photo_id) ->
         client.getvideoinformation(user_id, photo_id).then (body) ->
             ipcsend 'getvideoinformation:result', conv_id, event_id, photo_id, body
+
+    ipc.on 'openlink', seqreq (ev, url) ->
+        Q.Promise (rs, rj) ->
+            shell.openExternal url
+            rs()
+    , true
 
     # we want to upload. in the order specified, with retry
     ipc.on 'uploadclipboardimage', seqreq (ev, spec) ->

--- a/src/ui/css/yakyak/messages.less
+++ b/src/ui/css/yakyak/messages.less
@@ -143,6 +143,22 @@
                 }
                 .attach {
                     margin-top: 4px;
+
+                    a {
+                        display: block;
+                        position: relative;
+
+                        .play_button {
+                            left: 0px;
+                            top: 0px;
+                            right: 0px;
+                            bottom: 0px;
+                            position: absolute;
+                            background-image: url(https://ssl.gstatic.com/dynamite/images/ic_play_black_whitearrow.png);
+                            background-position: center;
+                            background-repeat: no-repeat;
+                        }
+                    }
                 }
                 img {
                     max-height: 350px;

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -60,9 +60,9 @@ handle 'chat_message', (ev) ->
     # if does not have user on cache
     entity.needEntity ev.sender_id.chat_id unless entity[ev.sender_id.chat_id]?
     # add chat to conversation
-    conv.addChatMessage ev
+    notifyEv = conv.addChatMessage ev
     # these messages are to go through notifications
-    notify.addToNotify ev
+    notify.addToNotify notifyEv
 
 handle 'watermark', (ev) ->
     conv.addWatermark ev


### PR DESCRIPTION
Currently they only show up as links - this fixes that by using the link to grab the thumbnail and proper href.