### PR TITLE
Fix unread status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6103,7 +6103,7 @@
       }
     },
     "node_modules/hangupsjs": {
-      "resolved": "git+ssh://git@github.com/yakyak/hangupsjs.git#152acbbad5b141b44e708a85b7b0b74c6a73b233",
+      "resolved": "git+ssh://git@github.com/yakyak/hangupsjs.git#69b2f09dad74f72ed1240bea60a59905eeb4e2d4",
       "dependencies": {
         "bog": "^1.0.0",
         "fnuc": "0.0.15",
@@ -18703,7 +18703,7 @@
       }
     },
     "hangupsjs": {
-      "version": "git+ssh://git@github.com/yakyak/hangupsjs.git#152acbbad5b141b44e708a85b7b0b74c6a73b233",
+      "version": "git+ssh://git@github.com/yakyak/hangupsjs.git#69b2f09dad74f72ed1240bea60a59905eeb4e2d4",
       "from": "hangupsjs@github:yakyak/hangupsjs",
       "requires": {
         "bog": "^1.0.0",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -513,9 +513,10 @@ app.on 'ready', ->
 
     # watermarking is only interesting for the last of each conv_id
     # retry send and dedupe for each conv_id
-    ipc.on 'updatewatermark', seqreq (ev, conv_id, time) ->
+    ipc.on 'updatewatermark', seqreq (ev, conv_id, event_id, time) ->
         client.updatewatermark conv_id, time
-    , true, (ev, conv_id, time) -> conv_id
+        client.markeventobserved conv_id, event_id
+    , true, (ev, conv_id, event_id, time) -> conv_id
 
     # getentity is not super important, the client will try again when encountering
     # entities without photo_url. so no retry, but do execute all such reqs

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -233,7 +233,7 @@ handle 'updatewatermark', do ->
         sendWater = throttleWaterByConv[conv_id]
         unless sendWater
             do (conv_id) ->
-                sendWater = throttle 1000, -> ipc.send 'updatewatermark', conv_id, Date.now()
+                sendWater = throttle 1000, -> ipc.send 'updatewatermark', conv_id, c.event?[c.event?.length - 1]?.timestamp / 1000
                 throttleWaterByConv[conv_id] = sendWater
         sendWater()
 

--- a/src/ui/dispatcher.coffee
+++ b/src/ui/dispatcher.coffee
@@ -233,7 +233,7 @@ handle 'updatewatermark', do ->
         sendWater = throttleWaterByConv[conv_id]
         unless sendWater
             do (conv_id) ->
-                sendWater = throttle 1000, -> ipc.send 'updatewatermark', conv_id, c.event?[c.event?.length - 1]?.timestamp / 1000
+                sendWater = throttle 1000, -> ipc.send 'updatewatermark', conv_id, c.event?[c.event?.length - 1]?.event_id, c.event?[c.event?.length - 1]?.timestamp / 1000
                 throttleWaterByConv[conv_id] = sendWater
         sendWater()
 


### PR DESCRIPTION
When updating the watermark the message/thread would sometimes not show as read (mainly in google chat for me), fix this by using the latest event timestamp instead of the current time. This also adds a new markeventobserved call which is called when the watermark is updated. This mimics what hangouts is doing.