### PR TITLE
Fix potential issue causing the unread state to not update

### DIFF
--- a/src/ui/models/viewstate.coffee
+++ b/src/ui/models/viewstate.coffee
@@ -156,7 +156,9 @@ module.exports = exp = {
         c = conv[@selectedConv]
         return unless c
         ur = conv.unread c
-        if ur > 0
+        # send updatewatermark if this is the first update, even if we have no unread messages
+        if ur > 0 or not c.watermark_updated?
+            c.watermark_updated = true
             later -> action 'updatewatermark'
 
     setSize: (size) ->


### PR DESCRIPTION
This sends updatewatermark once on first focus, even if we have no unread messages. This fixes an issue where the unread state sometimes gets stuck, where it will show as unread in other clients (google chat), but in yakyak it'll show as read - and since updatewatermark was only called if yakyak found any unread messages, it would never be called.