### PR TITLE
Sync client cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4616,7 +4616,7 @@
       }
     },
     "node_modules/hangupsjs": {
-      "resolved": "git+ssh://git@github.com/yakyak/hangupsjs.git#69b2f09dad74f72ed1240bea60a59905eeb4e2d4",
+      "resolved": "git+ssh://git@github.com/yakyak/hangupsjs.git#1a2db2e25201e1fb15977a2865d59d98308fd817",
       "dependencies": {
         "bog": "^1.0.0",
         "fnuc": "0.0.15",
@@ -13664,7 +13664,7 @@
       }
     },
     "hangupsjs": {
-      "version": "git+ssh://git@github.com/yakyak/hangupsjs.git#69b2f09dad74f72ed1240bea60a59905eeb4e2d4",
+      "version": "git+ssh://git@github.com/yakyak/hangupsjs.git#1a2db2e25201e1fb15977a2865d59d98308fd817",
       "from": "hangupsjs@github:yakyak/hangupsjs",
       "requires": {
         "bog": "^1.0.0",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -108,7 +108,6 @@ app.on 'activate', ->
 #  if user sees this html then it's an error and it tells how to report it
 loadAppWindow = ->
     mainWindow.loadURL 'file://' + YAKYAK_ROOT_DIR + '/ui/index.html'
-
     mainWindow.webContents.on 'did-finish-load', () ->
         customcss = path.join path.normalize(app.getPath('userData')), 'colorscheme', 'custom.css'
         csskey = null
@@ -348,10 +347,12 @@ app.on 'ready', ->
     # attempts to the client.
     reconnect = ->
         console.log 'reconnecting', reconnectCount
+
         proxycheck().then ->
             client.connect(creds)
             .then ->
                 console.log 'connected', reconnectCount
+                client.syncCookies mainWindow.webContents.session
                 # on first connect, send init, after that only resync
                 if reconnectCount == 0
                     log.debug 'Sending init...'


### PR DESCRIPTION
We can sometimes end up in a situation where the client has cookies, but the web session doesn't. This causes issues with loading certain things like thumbnails (see #1380).
To prevent this we sync cookies from the client to the web session.